### PR TITLE
fix: Pull Docker image before inspection in security scan

### DIFF
--- a/.github/workflows/sbom-security-scan.yml
+++ b/.github/workflows/sbom-security-scan.yml
@@ -130,6 +130,8 @@ jobs:
 
           # Check for root user
           FIRST_TAG=$(echo "${{ inputs.image-tags }}" | head -n1)
+          # Pull the image first since it was pushed in the previous job
+          docker pull "${FIRST_TAG}"
           USER=$(docker inspect "${FIRST_TAG}" | jq -r '.[0].Config.User')
           if [ -z "$USER" ] || [ "$USER" = "root" ] || [ "$USER" = "0" ]; then
             echo "⚠️  WARNING: Container runs as root user" >> policy-report.txt


### PR DESCRIPTION
### **User description**
## Summary
- Add docker pull command before docker inspect in Security policy checks step
- Fixes error when trying to inspect images that were pushed to registry but not available locally

## Problem
The security scan workflow was failing because it tried to inspect Docker images that weren't available locally. The images were pushed to the registry in the build job but the security-scan job didn't have them locally.

## Solution  
Added `docker pull` command before `docker inspect` to ensure the image is available locally for inspection.

## Test Plan
- [x] Workflow runs successfully after this change
- [x] Security policy checks complete without errors


___

### **PR Type**
Bug fix


___

### **Description**
- Add `docker pull` command before `docker inspect` in security scan workflow

- Fix error when inspecting Docker images not available locally

- Ensure images pushed to registry are pulled before inspection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Security Scan Job"] --> B["Pull Docker Image"]
  B --> C["Inspect Image"]
  C --> D["Security Policy Checks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sbom-security-scan.yml</strong><dd><code>Add Docker pull before image inspection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sbom-security-scan.yml

<ul><li>Add <code>docker pull</code> command before <code>docker inspect</code> in security policy <br>checks<br> <li> Include comment explaining why image needs to be pulled locally<br> <li> Fix workflow failure when inspecting images pushed in previous job</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/figure-collector-backend/pull/19/files#diff-7d48351c47cd32109ef3e416a8d653dd1807980329b3890ab7a6b8731e9931c0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

