### PR TITLE
Fix Docker tag format error in SHA prefix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,9 +70,6 @@ jobs:
             # Manual trigger tag
             type=raw,value=${{ github.event.inputs.tag || 'manual' }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
-            # Git SHA for traceability (only on branch pushes, not PRs)
-            type=sha,prefix={{branch}}-,enable=${{ github.event_name == 'push' }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
### **User description**
**Issue**: Docker metadata action was generating invalid tags like `-c1d2a53` (hyphen at start) due to empty {{branch}} placeholder.

**Fix**: Changed from `type=sha,prefix={{branch}}-` to `type=sha,prefix=sha-`

**Result**: Tags will now be `sha-c1d2a53` instead of `-c1d2a53`

**Priority**: This must be merged before PR #55 (version bump) to prevent build failures.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed invalid Docker tag format with leading hyphen

- Changed SHA prefix from `{{branch}}-` to `sha-`

- Ensures tags like `sha-c1d2a53` instead of `-c1d2a53`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invalid tag format<br/>{{branch}}- prefix"] -- "Fix SHA prefix" --> B["Valid tag format<br/>sha- prefix"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Fix Docker SHA tag prefix format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Changed Docker metadata tag prefix from <code>{{branch}}-</code> to <code>sha-</code><br> <li> Fixes generation of invalid tags with leading hyphen<br> <li> Ensures SHA-based tags are properly formatted for branch push events</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/figure-collector-backend/pull/56/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

