### PR TITLE
fix: Correct Docker workflow tag trigger configuration

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,11 +4,11 @@ on:
   # Automatic triggers
   push:
     branches: [develop, main]
+    tags:
+      - 'v*.*.*'  # Semantic version tags like v1.0.0, v1.0.0-application
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened]
-    tags:
-      - 'v*.*.*'  # Semantic version tags like v1.0.0
 
   # Manual trigger from GitHub Actions UI
   workflow_dispatch:


### PR DESCRIPTION
### **User description**
## Problem

The Docker workflow had `tags:` incorrectly placed under `pull_request:` instead of `push:`, preventing automatic Docker image builds when version tags are pushed.

**Impact**: When we pushed `v2.0.1-application` tags, no Docker builds were triggered.

## Solution

Moved `tags:` configuration from `pull_request:` section to `push:` section.

**Before:**
```yaml
push:
  branches: [develop, main]
pull_request:
  branches: [develop, main]
  types: [opened, synchronize, reopened]
  tags:  # ← WRONG LOCATION
    - 'v*.*.*'
```

**After:**
```yaml
push:
  branches: [develop, main]
  tags:  # ← CORRECT LOCATION
    - 'v*.*.*'
pull_request:
  branches: [develop, main]
  types: [opened, synchronize, reopened]
```

## Testing

After merge, we can test by:
1. Manually triggering workflow for `v2.0.1-application` tag
2. Verifying Docker images are built with application tags

## Priority

🔴 **CRITICAL** - This fix must be in place before workflow propagates to other projects.


___

### **PR Type**
Bug fix


___

### **Description**
- Move `tags` trigger from `pull_request` to `push` section

- Enable automatic Docker builds when version tags pushed

- Fix prevents missing builds for semantic version tags


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pull_request section<br/>with tags config"] -- "move tags" --> B["push section<br/>with tags config"]
  B -- "enables" --> C["Automatic Docker builds<br/>on tag push"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Correct Docker workflow tag trigger location</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Relocated <code>tags</code> configuration from <code>pull_request</code> section to <code>push</code> section<br> <li> Tags pattern <code>v*.*.*</code> now triggers builds on version tag pushes<br> <li> Updated comment to clarify support for application tags like <br><code>v1.0.0-application</code></ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/figure-collector-backend/pull/58/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

