### PR TITLE
Hotfix v3.0.3: Fix Atlas Search compound query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fc-backend",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fc-backend",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dependencies": {
         "axios": "^1.12.0",
         "bcryptjs": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fc-backend",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Backend API for figure collection management",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### **User description**
## Summary
- Fix Atlas Search to use compound query for both `name` AND `manufacturer` fields (previously only searched `name`)
- Update minimum query length from 2 to 3 characters to match Atlas Search minGrams configuration
- Version bump to v3.0.3

## Root Cause
The production Atlas Search query only searched the `name` field, while the regex fallback (used in dev/test) searched both `name` and `manufacturer`. This caused search to miss results when searching by manufacturer in production.

## Changes
- `src/services/searchService.ts`: Use `compound.should` with `autocomplete` on both fields, `minimumShouldMatch: 1`
- Update both `wordWheelSearch` and `partialSearch` to require 3-character minimum

## Index Configuration Required
```json
{
  "mappings": {
    "dynamic": false,
    "fields": {
      "name": {"type": "autocomplete", "tokenization": "nGram", "minGrams": 3, "maxGrams": 15, "foldDiacritics": true},
      "manufacturer": {"type": "autocomplete", "tokenization": "nGram", "minGrams": 3, "maxGrams": 15, "foldDiacritics": true},
      "scale": {"type": "string", "analyzer": "lucene.keyword"}
    }
  }
}
```

## Test Plan
- [x] All 438 tracked tests pass
- [ ] Verify search works in production with updated index


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Atlas Search to use compound query for both name and manufacturer fields

- Update minimum query length from 2 to 3 characters to match Atlas Search minGrams configuration

- Version bump to v3.0.3


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Search Query"] --> B["Minimum 3 Characters"]
  B --> C["Atlas Search Compound Query"]
  C --> D["Name Field"]
  C --> E["Manufacturer Field"]
  D --> F["Results"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>searchService.ts</strong><dd><code>Implement compound query for dual-field search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/searchService.ts

<ul><li>Changed minimum query length from 2 to 3 characters in both <br><code>wordWheelSearch</code> and <code>partialSearch</code> functions<br> <li> Updated <code>wordWheelSearch</code> Atlas Search query to use <code>compound.should</code> with <br>autocomplete on both <code>name</code> and <code>manufacturer</code> fields<br> <li> Added <code>minimumShouldMatch: 1</code> to compound query to match either field<br> <li> Updated comments to clarify minGrams configuration alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/fc-backend/pull/116/files#diff-9fbac0d9bb0630b5f2001d4503a7131f5f5245a7c4efb0cd312e7d24bccb8400">+29/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Version bump to 3.0.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Version bumped from 3.0.2 to 3.0.3


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/fc-backend/pull/116/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

