### PR TITLE
Fix zombie sync sessions and document BACKEND_URL config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,10 @@ SCRAPER_SERVICE_URL=http://localhost:3080
 # ENABLE_ATLAS_SEARCH=true
 
 # Debug Logging (optional)
-# Enable debug output for specific namespaces
-# DEBUG=backend:*
-# DEBUG=backend:auth
-# DEBUG=backend:registration
+# DEBUG=true enables all application loggers (AUTH, SYNC, MAIN, etc.)
+# DEBUG_LEVEL=verbose|info|warn|error (default: info in development, error in production)
+# DEBUG_MODULES=AUTH,SYNC,MAIN (enable specific modules only, or * for all)
+# DEBUG=true
+# DEBUG_LEVEL=info
+# DEBUG_MODULES=*
 # SERVICE_AUTH_TOKEN_DEBUG=false

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ See `.env.example` for complete configuration template. Run `./setup-local-env.s
   - Docker prod: `http://scraper:3050`
   - Docker Coolify dev: `http://scraper-dev:3090`
   - (Must match service/network name for container DNS resolution)
+- `BACKEND_URL`: Public URL of this backend service (used in webhook URLs sent to scraper)
+  - Local dev: `http://localhost:5080`
+  - Docker prod: `http://backend:5050`
+  - Docker Coolify dev: `http://backend:5090`
+  - (Must be reachable from the scraper container for sync webhook callbacks)
 - `PORT`: Port for backend service (prod: 5050, local dev: 5080)
 - `NODE_ENV`: Environment (development/production)
 
@@ -195,7 +200,9 @@ See `.env.example` for complete configuration template. Run `./setup-local-env.s
   - Falls back to regex search when not set or when `TEST_MODE=memory`
 
 **Debug Logging:**
-- `DEBUG`: Enable debug namespaces (e.g., `backend:*`, `backend:auth`, `backend:registration`)
+- `DEBUG`: Set to `true` to enable all application loggers (AUTH, SYNC, MAIN, DATABASE, etc.)
+- `DEBUG_LEVEL`: Log level threshold — `verbose`, `info`, `warn`, or `error` (default: `info` in development, `error` in production)
+- `DEBUG_MODULES`: Comma-separated list of modules to enable (e.g., `AUTH,SYNC`), or `*` for all. Only needed if `DEBUG` is not `true`
 - `SERVICE_AUTH_TOKEN_DEBUG`: Show partial tokens in logs for debugging (default: false)
 
 **Security Note:**

--- a/orchestration/.env.dev
+++ b/orchestration/.env.dev
@@ -19,6 +19,8 @@ SCRAPER_PORT=3090
 
 # Service URLs (internal Docker network)
 SCRAPER_SERVICE_URL=http://scraper:3090
+# BACKEND_URL is set on the SCRAPER container for webhook callbacks to backend
+BACKEND_URL=http://backend:5090
 
 # Database
 MONGODB_URI=mongodb://mongodb:27017/figure-collector-dev

--- a/orchestration/.env.example
+++ b/orchestration/.env.example
@@ -21,8 +21,10 @@ BACKEND_PORT=5090
 FRONTEND_PORT=5091
 SCRAPER_PORT=3090
 
-# URLs
+# URLs (inter-service communication)
 SCRAPER_SERVICE_URL=http://scraper-dev:3090
+# BACKEND_URL is set on the SCRAPER container for webhook callbacks to backend
+BACKEND_URL=http://fc-backend-dev:5090
 
 # Database & Auth (MUST be customized for each environment)
 MONGODB_URI=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/figure-collector-dev?retryWrites=true&w=majority

--- a/orchestration/.env.prod
+++ b/orchestration/.env.prod
@@ -16,8 +16,10 @@ BACKEND_PORT=5050
 FRONTEND_PORT=5051
 SCRAPER_PORT=3050
 
-# URLs
+# URLs (inter-service communication)
 SCRAPER_SERVICE_URL=http://scraper:3050
+# BACKEND_URL is set on the SCRAPER container for webhook callbacks to backend
+BACKEND_URL=http://fc-backend:5050
 
 # Database & Auth (set these for each environment)
 MONGODB_URI=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/figure-collector?retryWrites=true&w=majority


### PR DESCRIPTION
## Summary
- Add stale session detection to auto-fail zombie SyncJobs that stopped receiving webhook updates (10min on-demand, 15min periodic cleanup)
- Document BACKEND_URL environment variable across orchestration env files and README
- BACKEND_URL is required on the **scraper** container for webhook callbacks to reach the backend in production/Docker

## Changes
- `src/routes/syncRoutes.ts`: Added `failStaleJob()`, `cleanupStaleSessions()` with periodic interval, and stale detection in `/sync/active-job` endpoint
- `orchestration/.env.prod`, `.env.dev`, `.env.example`: Added BACKEND_URL configuration
- `README.md`: Documented BACKEND_URL in Environment Variables section

## Test plan
- [ ] Backend unit/integration tests pass (803/803)
- [ ] Stale session detection triggers after 10 minutes of inactivity on active-job check
- [ ] Periodic cleanup runs every 5 minutes and fails sessions stale >15 minutes
- [ ] Verify BACKEND_URL is correctly set in Coolify dev environment