### PR TITLE
Merge back v3.1.2 release to develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fc-backend",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fc-backend",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "dependencies": {
         "axios": "^1.13.5",
         "bcryptjs": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fc-backend",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Backend API for figure collection management",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Merge the v3.1.2 release (version bump) back to develop to keep branches in sync.