### PR TITLE
Release v3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fc-backend",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fc-backend",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "dependencies": {
         "axios": "^1.13.5",
         "bcryptjs": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fc-backend",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Backend API for figure collection management",
   "main": "dist/index.js",
   "scripts": {

--- a/src/routes/syncRoutes.ts
+++ b/src/routes/syncRoutes.ts
@@ -127,13 +127,16 @@ async function processScrapedArtists(
 
 const router = express.Router();
 
-// General rate limiter applied to all sync routes
+// General rate limiter for user-facing sync routes
+// Webhook routes (/webhook/*) are exempt — they use HMAC signature auth
+// and must handle high-throughput item-complete callbacks during sync
 const generalSyncLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100, // 100 requests per 15 minutes
   message: { success: false, message: 'Too many requests, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,
+  skip: (req) => req.path.startsWith('/webhook/'),
 });
 router.use(generalSyncLimiter);
 


### PR DESCRIPTION
## Summary
- Exempt webhook routes from general sync rate limiter to prevent 429s on internal scraper→backend callbacks during bulk sync

## Changes since v3.1.2
- `fix/webhook-rate-limit-bypass`: Added `skip` function to `generalSyncLimiter` for `/webhook/*` paths

## Test plan
- [x] All 785 backend tests pass
- [x] CodeQL clean
- [ ] Verify sync completes without 429 webhook rejections on prod