### PR TITLE
Add variant field to releases validation schema

### DIFF
--- a/src/middleware/validationMiddleware.ts
+++ b/src/middleware/validationMiddleware.ts
@@ -252,6 +252,7 @@ export const schemas = {
       currency: Joi.string().max(10).allow('').optional(),
       jan: Joi.string().max(15).allow('').optional(),
       isRerelease: Joi.boolean().optional(),
+      variant: Joi.string().max(200).allow('').optional(),
     })).optional(),
 
     // Release info (flat form fields mapped to releases array)
@@ -374,6 +375,7 @@ export const schemas = {
       currency: Joi.string().max(10).allow('').optional(),
       jan: Joi.string().max(15).allow('').optional(),
       isRerelease: Joi.boolean().optional(),
+      variant: Joi.string().max(200).allow('').optional(),
     })).optional(),
 
     // Release info (flat form fields - legacy)


### PR DESCRIPTION
## Summary
- Adds `variant` field to releases array validation in both figureCreate and figureUpdate Joi schemas
- Fixes 422 validation error when saving figures with release variant data from MFC scraper

## Test plan
- [x] All 954 backend tests pass
- [x] Verified no regression in validation middleware