### PR TITLE
feat: tracing on by default in prod + fix no-collector log correlation

### DIFF
--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -5,14 +5,18 @@
  * auto-instrumentation can patch them — `src/index.ts` imports this on its first
  * line.
  *
- * Behaviour is env-gated and SAFE BY DEFAULT:
- *   - disabled entirely under test (NODE_ENV=test / TEST_MODE=memory) so
- *     auto-instrumentation never interferes with the suite;
- *   - on outside production (benefit early in dev), opt-in for production — set
- *     OTEL_TRACES_ENABLED=true (or =false to force off anywhere);
- *   - spans are EXPORTED only when OTEL_EXPORTER_OTLP_ENDPOINT is set. With no
+ * Behaviour splits into two independent gates:
+ *   - RUN THE SDK (create spans, patch http/express/mongoose, expose the traceId
+ *     to logs): ON by default everywhere EXCEPT test. Disabled under test
+ *     (NODE_ENV=test / TEST_MODE=memory) so auto-instrumentation never adds
+ *     global state/flakiness to the suite. Kill switch: OTEL_TRACES_ENABLED=false.
+ *   - EXPORT spans off-box: only when OTEL_EXPORTER_OTLP_ENDPOINT is set. With no
  *     endpoint, spans are still created (so the traceId flows into every log
- *     line) but nothing is shipped — no collector required, no connection errors.
+ *     line) but nothing is shipped — no collector required, no connection errors,
+ *     no telemetry leaving the host until a secured collector exists.
+ *
+ * So production gets traceId-correlated logs immediately, while data only leaves
+ * the host once you point it at a (mTLS-secured) collector.
  *
  * This is the "instrument now, ship dark, flip on a collector later" split: the
  * day a Tempo/OTLP endpoint exists, set the env var and full traces flow with no
@@ -26,19 +30,43 @@ import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentation
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { SimpleSpanProcessor, SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+
+/**
+ * A SpanExporter that ships nothing. Paired with a real SimpleSpanProcessor it
+ * keeps the TracerProvider RECORDING — so spans have real trace IDs that flow
+ * into logs — while exporting zero telemetry off-box. This is the correct
+ * "instrument without shipping" primitive when no collector is configured.
+ * (OTEL_TRACES_EXPORTER=none, by contrast, disables tracing entirely, leaving
+ * an all-zero/no-op span context and NO trace IDs in logs.)
+ */
+class NoopSpanExporter implements SpanExporter {
+  export(_spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}
 
 /**
  * Pure decision: should the tracing SDK start for this environment?
  * Exported so the gate logic can be tested without side effects.
  */
 export function shouldEnableTracing(env: NodeJS.ProcessEnv = process.env): boolean {
-  // Never under tests — auto-instrumentation would interfere with the suite.
+  // Never under tests — auto-instrumentation adds global state/flakiness, and
+  // tracing behaviour is covered deterministically by its own unit tests.
   if (env.NODE_ENV === 'test' || env.TEST_MODE === 'memory') return false;
-  // Explicit override always wins.
-  if (env.OTEL_TRACES_ENABLED === 'true') return true;
+  // Kill switch: OTEL_TRACES_ENABLED=false force-disables anywhere (e.g. to
+  // isolate a suspected instrumentation regression in prod). Any other value
+  // (set or unset) leaves tracing enabled.
   if (env.OTEL_TRACES_ENABLED === 'false') return false;
-  // Default: on in dev (benefit early), opt-in for production (DoD caution).
-  return env.NODE_ENV !== 'production';
+  // On by default everywhere else — PRODUCTION INCLUDED — so logs get traceId
+  // correlation immediately. EXPORT is gated separately in startTracing() (only
+  // when OTEL_EXPORTER_OTLP_ENDPOINT is set), so no telemetry leaves the host
+  // until a secured collector exists.
+  return true;
 }
 
 let sdk: NodeSDK | undefined;
@@ -51,24 +79,25 @@ export function startTracing(env: NodeJS.ProcessEnv = process.env): NodeSDK | un
   if (sdk || !shouldEnableTracing(env)) return sdk;
 
   const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT;
-  // No collector configured -> create spans (traceId for logs) but export nothing.
-  if (!endpoint && !env.OTEL_TRACES_EXPORTER) {
-    process.env.OTEL_TRACES_EXPORTER = 'none';
-  }
 
   sdk = new NodeSDK({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: env.OTEL_SERVICE_NAME || 'fc-backend',
       [ATTR_SERVICE_VERSION]: process.env.npm_package_version || 'dev',
     }),
-    // When an endpoint is set, OTLPTraceExporter reads it from the environment.
-    traceExporter: endpoint ? new OTLPTraceExporter() : undefined,
+    // With a collector endpoint -> export via OTLP (OTLPTraceExporter reads the
+    // endpoint from the env). Without one -> keep the provider RECORDING (real
+    // trace IDs for log correlation) but drop spans through a no-op exporter, so
+    // nothing leaves the host and there are no connection errors.
+    ...(endpoint
+      ? { traceExporter: new OTLPTraceExporter() }
+      : { spanProcessors: [new SimpleSpanProcessor(new NoopSpanExporter())] }),
     instrumentations: [getNodeAutoInstrumentations()],
   });
 
   sdk.start();
   // eslint-disable-next-line no-console
-  console.log(`[TRACING] OpenTelemetry started for fc-backend (export: ${endpoint || 'none'})`);
+  console.log(`[TRACING] OpenTelemetry started for fc-backend (export: ${endpoint || 'off — recording for log correlation only'})`);
 
   const shutdown = (): void => {
     const current = sdk;

--- a/tests/unit/tracing.test.ts
+++ b/tests/unit/tracing.test.ts
@@ -16,14 +16,16 @@ describe('shouldEnableTracing', () => {
     expect(shouldEnableTracing({ TEST_MODE: 'memory', OTEL_TRACES_ENABLED: 'true' })).toBe(false);
   });
 
-  it('honors the explicit OTEL_TRACES_ENABLED override', () => {
-    expect(shouldEnableTracing({ OTEL_TRACES_ENABLED: 'true', NODE_ENV: 'production' })).toBe(true);
+  it('treats OTEL_TRACES_ENABLED=false as a kill switch anywhere', () => {
     expect(shouldEnableTracing({ OTEL_TRACES_ENABLED: 'false', NODE_ENV: 'development' })).toBe(false);
+    expect(shouldEnableTracing({ OTEL_TRACES_ENABLED: 'false', NODE_ENV: 'production' })).toBe(false);
+    expect(shouldEnableTracing({ OTEL_TRACES_ENABLED: 'false' })).toBe(false);
   });
 
-  it('defaults on outside production, off in production', () => {
+  it('defaults on everywhere outside test — production included', () => {
     expect(shouldEnableTracing({ NODE_ENV: 'development' })).toBe(true);
     expect(shouldEnableTracing({})).toBe(true);
-    expect(shouldEnableTracing({ NODE_ENV: 'production' })).toBe(false);
+    expect(shouldEnableTracing({ NODE_ENV: 'production' })).toBe(true);
+    expect(shouldEnableTracing({ NODE_ENV: 'production', OTEL_TRACES_ENABLED: 'true' })).toBe(true);
   });
 });


### PR DESCRIPTION
Follow-up to #187.

## Two changes

1. **SDK on by default everywhere except test (production included).** `shouldEnableTracing` now returns true unless `NODE_ENV=test`/`TEST_MODE=memory` (always off) or `OTEL_TRACES_ENABLED=false` (kill switch). So prod gets traceId-correlated logs immediately. Export stays gated separately on `OTEL_EXPORTER_OTLP_ENDPOINT`, so no telemetry leaves the host until a (mTLS-secured) collector exists — the two gates are independent.

2. **Fixes a real bug #187 shipped:** the no-collector path used `OTEL_TRACES_EXPORTER=none`, which makes the SDK register a **no-op** tracer provider — spans get an all-zero context and **no traceId reaches the logs**. Replaced it with a real `SimpleSpanProcessor` wrapping a `NoopSpanExporter`: the provider keeps **recording** (real trace IDs for logs) while shipping nothing off-box.

## Evidence (caught by a verification script, not assumed)

Before fix, under `NODE_ENV=production` + no collector: active span traceId = `0000…0000`, logs carried no trace tag — **FAIL**. After fix: real traceId `7de29e4cb89385243b8317fdde2656ba`, log line carried it — **PASS**.

## Verification

- Gate + correlation unit tests updated (production now defaults on; `=false` kill switch) — 6/6 green.
- **Full suite: 53 suites, 960 tests, zero regression.**

Kill switch to disable in prod if an instrumentation ever misbehaves: `OTEL_TRACES_ENABLED=false`.