### PR TITLE
Consume fc-shared trace context + wire GitHub Packages auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout code
@@ -23,6 +26,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run linter
         run: npm run lint || true
@@ -44,6 +49,9 @@ jobs:
     name: Build Application
     runs-on: ubuntu-latest
     needs: unit-tests
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout code
@@ -57,6 +65,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build application
         run: npm run build

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -89,6 +89,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            node_auth_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Debug - Show generated tags
         run: |
@@ -158,6 +160,9 @@ jobs:
   pr-security-scan:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -175,6 +180,8 @@ jobs:
           tags: local-scan:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            node_auth_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Install security tools
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -57,6 +57,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      packages: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -72,6 +73,8 @@ jobs:
           tags: fc-backend:scan
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            node_auth_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy container scan
         uses: aquasecurity/trivy-action@master
@@ -93,6 +96,9 @@ jobs:
   npm-audit:
     name: NPM Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -105,6 +111,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run npm audit
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@figurecollecting:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,20 @@ RUN apk update && \
     npm install -g npm@latest && \
     npm cache clean --force
 
-# Copy package files
-COPY package*.json ./
+# Copy package files (.npmrc maps @figurecollecting to GitHub Packages; it carries
+# only a ${NODE_AUTH_TOKEN} placeholder, never a real token)
+COPY package*.json .npmrc ./
 
 # ============================================================================
 # Development Stage - For local development with hot reload
 # ============================================================================
 FROM base AS development
 
-# Install all dependencies (including dev dependencies)
-RUN npm ci
+# Install all dependencies (including dev dependencies).
+# Token is provided via a BuildKit secret mount — exposed only for this RUN,
+# never written to a layer or visible in `docker history`.
+RUN --mount=type=secret,id=node_auth_token \
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" npm ci
 
 # Copy source code
 COPY . .
@@ -47,7 +51,8 @@ CMD ["npm", "run", "dev"]
 FROM base AS test
 
 # Install all dependencies (including dev dependencies for testing)
-RUN npm ci
+RUN --mount=type=secret,id=node_auth_token \
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" npm ci
 
 # Copy source code
 COPY . .
@@ -62,7 +67,8 @@ FROM base AS builder
 
 # Install all dependencies (including dev for building)
 # Using --ignore-scripts for security to prevent execution of npm scripts
-RUN npm ci --ignore-scripts
+RUN --mount=type=secret,id=node_auth_token \
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" npm ci --ignore-scripts
 
 # Copy source code
 COPY . .
@@ -102,12 +108,14 @@ RUN apk add --no-cache dumb-init && \
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Copy package files (.npmrc maps @figurecollecting to GitHub Packages; placeholder token only)
+COPY package*.json .npmrc ./
 
 # Install production dependencies only
-# Using --ignore-scripts for security to prevent execution of npm scripts
-RUN npm ci --omit=dev --ignore-scripts && \
+# Using --ignore-scripts for security to prevent execution of npm scripts.
+# Token via BuildKit secret mount — never written to a layer.
+RUN --mount=type=secret,id=node_auth_token \
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" npm ci --omit=dev --ignore-scripts && \
     npm cache clean --force
 
 # Copy built application from builder

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fc-backend",
       "version": "3.2.0",
       "dependencies": {
+        "@figurecollecting/fc-shared": "^1.2.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.76.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
@@ -1045,6 +1046,20 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@figurecollecting/fc-shared": {
+      "version": "1.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@figurecollecting/fc-shared/1.2.1/ed3cfd2e1739e88d4e2eec9c24e3978e9fffc946",
+      "integrity": "sha512-NtQsJyyqEk95KDdv1fQQtnUPCBl6TIuE2r3IQ50JWlAYYLf6ArWXsG1bl5+D8j1btxZuBHRHbDlzXjdEAE6VAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "axios": "^1.16.1",
+        "zustand": "^5.0.14"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -8848,6 +8863,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -10523,6 +10548,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:ci": "NODE_OPTIONS=--experimental-vm-modules TEST_MODE=memory node node_modules/jest/bin/jest.js --ci --coverage --testPathIgnorePatterns='cross-service|inter-service|performance'"
   },
   "dependencies": {
+    "@figurecollecting/fc-shared": "^1.2.1",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.76.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -10,7 +10,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { trace } from '@opentelemetry/api';
+import { getTraceContext } from '@figurecollecting/fc-shared';
 
 const DEBUG = process.env.DEBUG === 'true';
 const TEST_MODE = process.env.TEST_MODE === 'memory' || process.env.NODE_ENV === 'test';
@@ -81,21 +81,6 @@ const LOG_LEVELS: Record<LogLevel, number> = {
   error: 3
 };
 
-/**
- * Returns `trace=<traceId> span=<spanId>` when an OpenTelemetry span is active,
- * or '' when there is none (outside a request, or tracing disabled — e.g. tests).
- * This is what threads a request's traceId through every log line for end-to-end
- * correlation once a tracing backend is attached. Safe no-op until then.
- */
-const traceContext = (): string => {
-  const span = trace.getActiveSpan();
-  if (!span) return '';
-  const ctx = span.spanContext();
-  // An all-zero traceId is the invalid/unsampled context — treat as none.
-  if (!ctx.traceId || /^0+$/.test(ctx.traceId)) return '';
-  return `trace=${ctx.traceId} span=${ctx.spanId}`;
-};
-
 class Logger {
   private readonly module: string;
   private readonly enabled: boolean;
@@ -113,7 +98,7 @@ class Logger {
    * is active. With no active span (all existing tests) the shape is unchanged.
    */
   private head(level: string): unknown[] {
-    const tc = traceContext();
+    const tc = getTraceContext();
     const base: unknown[] = [`[${this.module}:${level}]`, new Date().toISOString()];
     return tc ? [...base, tc] : base;
   }


### PR DESCRIPTION
## What
Replaces fc-backend's local `traceContext` helper with the shared `getTraceContext` from `@figurecollecting/fc-shared@^1.2.1`, and wires GitHub Packages authentication through CI and Docker so the private package installs everywhere.

### Code
- `src/utils/logger.ts`: import `getTraceContext` from fc-shared; delete the byte-identical local helper (incl. all-zero traceId guard) and the now-unused `@opentelemetry/api` import. The `trace=<id> span=<id>` log-tag format is now owned in one place (fc-shared).
- `package.json`: add `@figurecollecting/fc-shared@^1.2.1` (the CJS-built, Node-consumable release).
- `.npmrc`: map `@figurecollecting` scope to npm.pkg.github.com; token via `${NODE_AUTH_TOKEN}` (placeholder only, never a real secret).

### CI / Docker auth
- `build.yml`, `security-scan.yml`: `packages: read` permission + `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on each `npm ci`.
- `Dockerfile`: copy `.npmrc` into base + production; every `npm ci` now uses a **BuildKit secret mount** (`--mount=type=secret,id=node_auth_token`) so the token authenticates the install but never lands in a layer or `docker history`.
- `docker-publish.yml`: pass `secrets: node_auth_token=${{ secrets.GITHUB_TOKEN }}` to both build-push steps; `packages: read` on the PR-scan job.

## Verified locally
- `require('@figurecollecting/fc-shared')` resolves getTraceContext/createLogger/getActiveTraceIds from the **registry-installed** 1.2.1 (CJS).
- `@opentelemetry/api` deduped to one instance → cross-package context singleton works: the logger-tracing test (real AsyncLocalStorageContextManager) reads the active span through fc-shared's helper. ✓
- `tsc --noEmit` clean; **979/979 unit+integration tests pass** (the 20 excluded failures are cross-service tests needing a live scraper on :5070 — doctrine-excluded from PRs, unrelated to this change).

## ⚠️ Required before CI is green: grant package access
The `fc-shared` package is **private** (linked to the fc-shared repo), so this repo's `GITHUB_TOKEN` can't read it until granted. One-time org action:
**Org → Packages → fc-shared → Package settings → Manage Actions access → Add repository → `fc-backend` → Read.**
(Same grant will be needed for scraper / fc-frontend / fc-mobile as they adopt fc-shared.) Until then, the `npm ci` steps 403 — expected, not a code defect.