### PR TITLE
Wire fc-shared redaction into logs and OTLP export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fc-backend",
       "version": "3.2.0",
       "dependencies": {
-        "@figurecollecting/fc-shared": "^1.2.1",
+        "@figurecollecting/fc-shared": "^1.3.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.76.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
@@ -1049,9 +1049,9 @@
       }
     },
     "node_modules/@figurecollecting/fc-shared": {
-      "version": "1.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@figurecollecting/fc-shared/1.2.1/ed3cfd2e1739e88d4e2eec9c24e3978e9fffc946",
-      "integrity": "sha512-NtQsJyyqEk95KDdv1fQQtnUPCBl6TIuE2r3IQ50JWlAYYLf6ArWXsG1bl5+D8j1btxZuBHRHbDlzXjdEAE6VAg==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@figurecollecting/fc-shared/1.3.0/0fc7bbaada8d37b687aca810971ae803e1ae1dbe",
+      "integrity": "sha512-FFuFMFKiw1cPdgocxTnKvN74d6NVkk88jJev9Zbr55L8uHQ63GMktbnUg7/vuGQhBYDBi+K222/k34eqpdx8Vw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:ci": "NODE_OPTIONS=--experimental-vm-modules TEST_MODE=memory node node_modules/jest/bin/jest.js --ci --coverage --testPathIgnorePatterns='cross-service|inter-service|performance'"
   },
   "dependencies": {
-    "@figurecollecting/fc-shared": "^1.2.1",
+    "@figurecollecting/fc-shared": "^1.3.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.76.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -32,6 +32,7 @@ import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { SimpleSpanProcessor, SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { redactAttributes } from '@figurecollecting/fc-shared';
 
 /**
  * A SpanExporter that ships nothing. Paired with a real SimpleSpanProcessor it
@@ -47,6 +48,26 @@ class NoopSpanExporter implements SpanExporter {
   }
   shutdown(): Promise<void> {
     return Promise.resolve();
+  }
+}
+
+/**
+ * Wraps a real SpanExporter and scrubs secrets/PII from each span's attributes
+ * before they leave the host. Active only when an OTLP endpoint is configured.
+ */
+export class RedactingSpanExporter implements SpanExporter {
+  constructor(private readonly delegate: SpanExporter) {}
+  export(spans: ReadableSpan[], cb: (r: ExportResult) => void): void {
+    for (const s of spans) {
+      (s as any).attributes = redactAttributes(s.attributes as any);
+    }
+    this.delegate.export(spans, cb);
+  }
+  shutdown(): Promise<void> {
+    return this.delegate.shutdown();
+  }
+  forceFlush(): Promise<void> {
+    return this.delegate.forceFlush ? this.delegate.forceFlush() : Promise.resolve();
   }
 }
 
@@ -90,7 +111,7 @@ export function startTracing(env: NodeJS.ProcessEnv = process.env): NodeSDK | un
     // trace IDs for log correlation) but drop spans through a no-op exporter, so
     // nothing leaves the host and there are no connection errors.
     ...(endpoint
-      ? { traceExporter: new OTLPTraceExporter() }
+      ? { traceExporter: new RedactingSpanExporter(new OTLPTraceExporter()) }
       : { spanProcessors: [new SimpleSpanProcessor(new NoopSpanExporter())] }),
     instrumentations: [getNodeAutoInstrumentations()],
   });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -10,7 +10,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { getTraceContext } from '@figurecollecting/fc-shared';
+import { getTraceContext, redactValue } from '@figurecollecting/fc-shared';
 
 const DEBUG = process.env.DEBUG === 'true';
 const TEST_MODE = process.env.TEST_MODE === 'memory' || process.env.NODE_ENV === 'test';
@@ -70,7 +70,8 @@ const sanitizeLogValue = (value: unknown): string => {
  * Uses JSON.stringify to break CodeQL taint tracking.
  */
 const sanitizeArgs = (args: unknown[]): string => {
-  const sanitized = args.map(arg => sanitizeLogValue(arg));
+  // Redact secrets/PII first (deep), THEN break taint flow with string sanitization.
+  const sanitized = args.map(arg => sanitizeLogValue(redactValue(arg)));
   return JSON.stringify(sanitized);
 };
 
@@ -193,7 +194,8 @@ export const syncLogger = {
     // Sanitize user-provided values before logging and file write
     const safeSessionId = sanitizeLogValue(event.sessionId);
     const safeMfcId = event.mfcId ? sanitizeLogValue(event.mfcId) : '';
-    const safeEntry = JSON.stringify(entry);
+    // Redact secrets/PII from the structured entry before serialization.
+    const safeEntry = JSON.stringify(redactValue(entry));
     const logLine = `[${timestamp}] [SYNC] ${event.event.toUpperCase()} session=${safeSessionId}${safeMfcId ? ` mfcId=${safeMfcId}` : ''} ${safeEntry}`;
 
     // Console output

--- a/tests/unit/loggerRedaction.test.ts
+++ b/tests/unit/loggerRedaction.test.ts
@@ -1,0 +1,67 @@
+import { createLogger } from '../../src/utils/logger';
+import { RedactingSpanExporter } from '../../src/tracing';
+import type { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+
+/**
+ * Proves fc-shared redaction is wired into both sinks:
+ *  - the logger redacts secrets/PII from log args before the existing
+ *    CWE-117 string sanitization runs, and
+ *  - RedactingSpanExporter scrubs span attributes before the delegate exports.
+ */
+describe('logger secret/PII redaction', () => {
+  let errSpy: jest.SpyInstance;
+  beforeEach(() => {
+    errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it('redacts a secret-bearing object and a Bearer token string to [REDACTED]', () => {
+    const log = createLogger('SECRETS');
+    log.error({ password: 'x', user: 'bob' }, 'Bearer abcdefghij');
+
+    // The sanitized JSON payload is the last arg of the single error call.
+    const call = errSpy.mock.calls[0];
+    const payload = call[call.length - 1] as string;
+
+    expect(payload).toContain('[REDACTED]');
+    // Secret values are gone; the non-secret field survives.
+    expect(payload).not.toContain('"password":"x"');
+    expect(payload).not.toContain('abcdefghij');
+    expect(payload).toContain('bob');
+  });
+});
+
+describe('RedactingSpanExporter', () => {
+  it('scrubs span attributes before the delegate receives them', () => {
+    let received: ReadableSpan[] | undefined;
+    const delegate: SpanExporter = {
+      export(spans: ReadableSpan[], cb: (r: ExportResult) => void): void {
+        received = spans;
+        cb({ code: ExportResultCode.SUCCESS });
+      },
+      shutdown(): Promise<void> {
+        return Promise.resolve();
+      },
+    };
+
+    const exporter = new RedactingSpanExporter(delegate);
+    const fakeSpan = {
+      attributes: { authorization: 'Bearer secret-token', 'http.method': 'GET' },
+    } as unknown as ReadableSpan;
+
+    let result: ExportResult | undefined;
+    exporter.export([fakeSpan], (r) => {
+      result = r;
+    });
+
+    expect(result).toEqual({ code: ExportResultCode.SUCCESS });
+    expect(received).toHaveLength(1);
+    const attrs = received![0].attributes as Record<string, unknown>;
+    expect(attrs.authorization).toBe('[REDACTED]');
+    // Non-sensitive attributes pass through untouched.
+    expect(attrs['http.method']).toBe('GET');
+  });
+});


### PR DESCRIPTION
Bump @figurecollecting/fc-shared to ^1.3.0 and wire its redaction helpers into both log/telemetry sinks.

- **Logger** (src/utils/logger.ts): layer `redactValue` into `sanitizeArgs` BEFORE the existing CWE-117 string sanitization, so secrets/PII are deep-stripped first, then taint-broken. Also redact the structured syncLogger entry before serialization. All existing logger features (CWE-117 sanitization, namespaces, trace tag, file logging) are preserved.
- **OTLP export** (src/tracing.ts): new `RedactingSpanExporter` wraps the real exporter and runs `redactAttributes` over each span's attributes before delegating. It wraps `OTLPTraceExporter` only on the endpoint branch, so it is active only when OTEL_EXPORTER_OTLP_ENDPOINT is set. The no-endpoint NoopSpanExporter branch is unchanged.
- Both fc-shared helpers are pure with no OpenTelemetry dependency.

Verification:
- `npx tsc --noEmit` clean.
- Full suite: 56 suites / 981 tests pass (TEST_MODE=memory, cross-service excluded); zero regression. Includes 2 new unit tests in tests/unit/loggerRedaction.test.ts asserting a logged payload with {password:'x'} and a 'Bearer abcdefghij' string is redacted to [REDACTED], and that a fake ReadableSpan with an 'authorization' attribute is scrubbed before the delegate receives it.
- `npm audit --omit=dev`: 0 high / 0 critical (6 pre-existing moderate, unrelated to this change).