### PR TITLE
Bump mongoose 8 -> 9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "express-rate-limit": "^8.5.2",
         "joi": "^18.2.1",
         "jsonwebtoken": "^9.0.3",
-        "mongoose": "^8.19.2",
+        "mongoose": "^9.7.0",
         "otpauth": "^9.5.0",
         "qrcode": "^1.5.4",
         "resend": "^6.9.3"
@@ -3766,6 +3766,7 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
@@ -4698,6 +4699,7 @@
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
       "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
@@ -7533,12 +7535,12 @@
       }
     },
     "node_modules/kareem": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
-      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.3.0.tgz",
+      "integrity": "sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/leven": {
@@ -7892,6 +7894,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
       "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
@@ -7964,48 +7967,65 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.0.tgz",
-      "integrity": "sha512-Bul4Ha6J8IqzFrb0B1xpVzkC3S0sk43dmLSnhFOn8eJlZiLwL5WO6cRymmjaADdCMjUcCpj2ce8hZI6O4ZFSug==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.7.0.tgz",
+      "integrity": "sha512-pkrLZ6U41pD4Ai0ju/FYL7o5I5k+rV3RZINQTG937hbhnLGKRuqqYm1Dlt/kTQ+M4FHijzV6JawzsdHKRGt7QA==",
       "license": "MIT",
       "dependencies": {
-        "bson": "^6.10.4",
-        "kareem": "2.6.3",
-        "mongodb": "~6.20.0",
+        "kareem": "3.3.0",
+        "mongodb": "~7.2",
         "mpath": "0.9.0",
-        "mquery": "5.0.0",
+        "mquery": "6.0.0",
         "ms": "2.1.3",
         "sift": "17.1.3"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose/node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongoose/node_modules/bson": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
+      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/mongoose/node_modules/mongodb": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
-      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
+      "integrity": "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.2"
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
         "snappy": "^7.3.2",
-        "socks": "^2.7.1"
+        "socks": "^2.8.6"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
@@ -8031,6 +8051,19 @@
         }
       }
     },
+    "node_modules/mongoose/node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/mpath": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
@@ -8041,15 +8074,12 @@
       }
     },
     "node_modules/mquery": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
-      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
+      "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4.x"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express-rate-limit": "^8.5.2",
     "joi": "^18.2.1",
     "jsonwebtoken": "^9.0.3",
-    "mongoose": "^8.19.2",
+    "mongoose": "^9.7.0",
     "otpauth": "^9.5.0",
     "qrcode": "^1.5.4",
     "resend": "^6.9.3"

--- a/src/models/Figure.ts
+++ b/src/models/Figure.ts
@@ -266,7 +266,7 @@ FigureSchema.index({ userId: 1, rating: -1 });
 FigureSchema.index({ name: 'text', manufacturer: 'text', tags: 'text' });
 
 // Schema v3: Derive manufacturer from companyRoles if not provided
-FigureSchema.pre('save', function (next) {
+FigureSchema.pre('save', function () {
   // If manufacturer is not set but we have companyRoles, derive it
   if (!this.manufacturer && this.companyRoles && this.companyRoles.length > 0) {
     // Find the first company with 'Manufacturer' role, or just use first company
@@ -278,7 +278,6 @@ FigureSchema.pre('save', function (next) {
       this.manufacturer = derivedManufacturer;
     }
   }
-  next();
 });
 
 export default mongoose.model<IFigure>('Figure', FigureSchema);

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -92,14 +92,13 @@ const UserSchema = new Schema<IUser>(
 );
 
 // Hash password before saving
-UserSchema.pre('save', async function(next) {
+UserSchema.pre('save', async function() {
   if (!this.isModified('password')) {
-    return next();
+    return;
   }
-  
+
   const salt = await bcrypt.genSalt(10);
   this.password = await bcrypt.hash(this.password, salt);
-  next();
 });
 
 // Method to compare passwords

--- a/tests/integration/database.test.ts
+++ b/tests/integration/database.test.ts
@@ -266,7 +266,11 @@ describe('Database Integration Tests', () => {
         }
         
       } catch (error: any) {
-        if (error.message.includes('Transaction') || error.message.includes('replica set')) {
+        if (
+          error.message.includes('Transaction') ||
+          error.message.includes('replica set') ||
+          error.message.includes('retryable writes')
+        ) {
           console.log('Skipping transaction test - transactions not supported (replica set required)');
         } else {
           throw error;
@@ -315,7 +319,11 @@ describe('Database Integration Tests', () => {
         }
         
       } catch (error: any) {
-        if (error.message.includes('Transaction') || error.message.includes('replica set')) {
+        if (
+          error.message.includes('Transaction') ||
+          error.message.includes('replica set') ||
+          error.message.includes('retryable writes')
+        ) {
           console.log('Skipping failed transaction test - transactions not supported');
         } else {
           // Expected behavior for duplicate key error


### PR DESCRIPTION
Bumps mongoose from ^8.19.2 to ^9.7.0 (latest stable in the v9 line; steps past Dependabot's 9.3.0 per compatibility research -- same major, no additional breaking changes). Bundled MongoDB driver moves 6.x -> 7.2.0.

Supersedes Dependabot #158.

## v9 breaking-change audit vs our usage

Reviewed the mongoose 8->9 migration guide against this codebase:

- **Update aggregation pipelines**: not used. All updateOne/updateMany/findOneAndUpdate/findByIdAndUpdate calls pass object update operators ($set, $addToSet, $pullAll, $setOnInsert), never pipeline arrays.
- **`background: true` index option**: not used.
- **Transactions / sessions**: no production usage (only an integration test that gracefully skips on standalone deployments).
- **Deprecated `count()` / `remove()`**: not used (we use countDocuments / deleteOne / deleteMany).
- Plain Schema + ObjectId models, single connect().

## Breaking change that DID intersect (code change required)

**Pre middleware no longer accepts a `next()` callback** (v9 migration guide). Two `pre('save')` hooks used the `next`-callback form and had to be migrated to the async/sync-return form:
- `src/models/User.ts` -- password-hash hook -> `async function()` with early `return`.
- `src/models/Figure.ts` -- manufacturer-derivation hook -> sync `function()` (dropped `next()`).

This surfaced as `tsc` errors (`Type 'SaveOptions' has no call signatures` -- the `next` param resolved to the wrong overload).

## Driver-7 behavior change surfaced by a test

The MongoDB 7.x driver changed the standalone-deployment error for transactions from a "replica set required" message to `This MongoDB deployment does not support retryable writes...`. `tests/integration/database.test.ts` skipped the transaction test by matching on `'Transaction'`/`'replica set'` substrings; added `'retryable writes'` to the skip condition in both transaction tests so they continue to skip gracefully on the standalone mongodb-memory-server.

## Verification

- `npx tsc --noEmit`: clean (exit 0).
- `TEST_MODE=memory npx jest --testPathIgnorePatterns='cross-service'`: **56 suites / 981 tests, all pass** (exercises mongodb-memory-server against driver 7). Confirmed zero regression -- baseline (v8) was checked in a throwaway worktree to prove the transaction-test skip behavior matched pre-bump.
- `npm audit --omit=dev`: 0 high, 0 critical (4 moderate, all pre-existing in resend's transitive deps, unrelated to this bump).
- `npm ls mongoose`: 9.7.0; bundled `mongodb`: 7.2.0.
- Lockfile regenerated via `npm install` (not hand-edited).