### PR TITLE
Bump Node to 26 (base image + CI) and mongodb-memory-server to 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'npm'
 
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run lint || true
 
       - name: Run unit tests with coverage
-        run: npm run test:ci -- --coverage
+        run: npm run test:ci -- --coverage --runInBand
         env:
           TEST_MODE: memory
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run lint || true
 
       - name: Run unit tests with coverage
-        run: npm run test:ci -- --coverage --runInBand
+        run: npm run test:ci -- --coverage
         env:
           TEST_MODE: memory
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'npm'
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================================================
 # Base Stage - Common foundation for all stages
 # ============================================================================
-FROM node:25-alpine AS base
+FROM node:26-alpine AS base
 
 # Cache-bust ARG to invalidate Docker layers when security patches are needed
 ARG CACHE_BUST=2026-06-12-openssl-cve-fix
@@ -79,7 +79,7 @@ RUN npm run build
 # ============================================================================
 # Production Stage - Optimized runtime image
 # ============================================================================
-FROM node:25-alpine AS production
+FROM node:26-alpine AS production
 
 # Cache-bust ARG for production stage security patches
 ARG CACHE_BUST=2026-06-12-openssl-cve-fix

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
+  globalSetup: '<rootDir>/tests/globalSetup.ts',
+  globalTeardown: '<rootDir>/tests/globalTeardown.ts',
   setupFilesAfterEnv: ['<rootDir>/tests/testSetup.ts'],
   testMatch: ['<rootDir>/tests/**/*.test.ts'],
   transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/supertest": "^7.2.0",
         "jest": "^30.4.2",
         "jest-extended": "^7.0.0",
-        "mongodb-memory-server": "^10.2.3",
+        "mongodb-memory-server": "^11.2.0",
         "node-fetch": "^3.3.2",
         "supertest": "^7.1.4",
         "ts-jest": "^29.4.6",
@@ -3763,10 +3763,9 @@
       "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "dev": true,
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
@@ -4314,9 +4313,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -4434,9 +4433,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -4449,9 +4448,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
-      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4474,9 +4473,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.0.tgz",
-      "integrity": "sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4484,9 +4483,9 @@
       }
     },
     "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4494,20 +4493,25 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
-      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "streamx": "^2.21.0",
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
         "teex": "^1.0.1"
       },
       "peerDependencies": {
+        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
         "bare-buffer": {
           "optional": true
         },
@@ -4517,9 +4521,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4696,13 +4700,12 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
+      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -7744,27 +7747,27 @@
       "license": "MIT"
     },
     "node_modules/mongodb": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
-      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.3.0.tgz",
+      "integrity": "sha512-WpCqSx7JAU9vcyjm/SU7ydnHls2YrfU3Y3sx4Ml9D7sPe4mXPlaapndiurDXrQ7/VvJkB4/i7b7WovHb8bd8sg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.2"
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
         "snappy": "^7.3.2",
-        "socks": "^2.7.1"
+        "socks": "^2.8.6"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
@@ -7791,35 +7794,37 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
-      "dev": true,
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/mongodb-memory-server": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.4.3.tgz",
-      "integrity": "sha512-CDZvFisXvGIigsIw5gqH6r9NI/zxGa/uRdutgUL/isuJh+inj0YXb7Ykw6oFMFzqgTJWb7x0I5DpzrqCstBWpg==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.2.0.tgz",
+      "integrity": "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "mongodb-memory-server-core": "10.4.3",
+        "mongodb-memory-server-core": "11.2.0",
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/mongodb-memory-server-core": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.4.3.tgz",
-      "integrity": "sha512-IPjlw73IoSYopnqBibQKxmAXMbOEPf5uGAOsBcaUiNH/TOI7V19WO+K7n5KYtnQ9FqzLGLpvwCGuPOTBSg4s5Q==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.2.0.tgz",
+      "integrity": "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7827,17 +7832,17 @@
         "camelcase": "^6.3.0",
         "debug": "^4.4.3",
         "find-cache-dir": "^3.3.2",
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "https-proxy-agent": "^7.0.6",
-        "mongodb": "^6.9.0",
+        "mongodb": "^7.2.0",
         "new-find-package-json": "^2.0.0",
         "semver": "^7.7.3",
-        "tar-stream": "^3.1.7",
+        "tar-stream": "^3.1.8",
         "tslib": "^2.8.1",
-        "yauzl": "^3.2.0"
+        "yauzl": "^3.3.1"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
@@ -7854,9 +7859,9 @@
       }
     },
     "node_modules/mongodb-memory-server-core/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7885,24 +7890,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "node_modules/mongoose/node_modules/@types/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/webidl-conversions": "*"
-      }
-    },
-    "node_modules/mongoose/node_modules/bson": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -7949,19 +7936,6 @@
         "socks": {
           "optional": true
         }
-      }
-    },
-    "node_modules/mongoose/node_modules/mongodb-connection-string-url": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^13.0.0",
-        "whatwg-url": "^14.1.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/mpath": {
@@ -9330,9 +9304,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9596,9 +9570,9 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/supertest": "^7.2.0",
     "jest": "^30.4.2",
     "jest-extended": "^7.0.0",
-    "mongodb-memory-server": "^10.2.3",
+    "mongodb-memory-server": "^11.2.0",
     "node-fetch": "^3.3.2",
     "supertest": "^7.1.4",
     "ts-jest": "^29.4.6",

--- a/tests/config/db.test.ts
+++ b/tests/config/db.test.ts
@@ -33,6 +33,9 @@ describe('Database Configuration', () => {
     
     // Restore environment
     process.env = { ...originalEnv };
+    // globalSetup sets TEST_MONGODB_URI to the in-memory server, which connectDB
+    // prefers over MONGODB_URI; clear it so this test exercises the MONGODB_URI path.
+    delete process.env.TEST_MONGODB_URI;
     process.env.MONGODB_URI = 'mongodb://localhost:27017/figure-collector';
     // Set NODE_ENV to production to test actual retry logic
     process.env.NODE_ENV = 'production';

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -1,0 +1,20 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+// Jest globalSetup runs ONCE in the Node main process (not inside the jest VM
+// sandbox). This is where we start a single shared in-memory MongoDB for the
+// whole run. Starting/stopping the server here keeps mongodb-memory-server's
+// process management (which relies on globals like setTimeout) in the real Node
+// runtime, avoiding the Node 26 teardown crash that occurs when stop() runs
+// inside the sandboxed jest VM during afterAll.
+export default async function globalSetup(): Promise<void> {
+  const instance = await MongoMemoryServer.create();
+  const uri = instance.getUri();
+
+  // Stash the instance so globalTeardown can stop the same server.
+  (globalThis as any).__MONGOINSTANCE = instance;
+
+  // Expose the URI to every worker process. testSetup.ts (setupFilesAfterEnv)
+  // and src/config/db.ts both read these env vars to connect mongoose.
+  process.env.MONGODB_URI = uri;
+  process.env.TEST_MONGODB_URI = uri;
+}

--- a/tests/globalTeardown.ts
+++ b/tests/globalTeardown.ts
@@ -1,0 +1,12 @@
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+
+// Jest globalTeardown runs ONCE in the Node main process after all suites
+// finish. Stopping the shared in-memory MongoDB here (rather than in an
+// afterAll inside a worker) keeps mongodb-memory-server's killProcess in the
+// real Node runtime where setTimeout exists, fixing the Node 26 teardown crash.
+export default async function globalTeardown(): Promise<void> {
+  const instance = (globalThis as any).__MONGOINSTANCE as MongoMemoryServer | undefined;
+  if (instance) {
+    await instance.stop();
+  }
+}

--- a/tests/integration/database/dbConnection.test.ts
+++ b/tests/integration/database/dbConnection.test.ts
@@ -20,6 +20,9 @@ describe('Database Connection Retry Logic', () => {
     
     // Restore environment
     process.env = { ...originalEnv };
+    // globalSetup sets TEST_MONGODB_URI to the in-memory server, which connectDB
+    // prefers over MONGODB_URI; clear it so this test exercises the MONGODB_URI path.
+    delete process.env.TEST_MONGODB_URI;
     process.env.MONGODB_URI = 'mongodb://localhost:27017/fc-db';
     // Set NODE_ENV to production to test actual retry logic
     process.env.NODE_ENV = 'production';

--- a/tests/testSetup.ts
+++ b/tests/testSetup.ts
@@ -1,44 +1,38 @@
 import mongoose from 'mongoose';
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import jwt from 'jsonwebtoken';
 import User from '../src/models/User';
 import Figure from '../src/models/Figure';
 
-let mongoServer: MongoMemoryServer;
-
-// Global testing setup
+// The in-memory MongoDB is started ONCE by jest globalSetup (tests/globalSetup.ts)
+// in the Node main process, and stopped by globalTeardown. The server's URI is
+// passed to every worker via process.env. Here we only connect/disconnect the
+// per-worker mongoose client to that shared server. Stopping the server outside
+// the jest VM sandbox avoids the Node 26 teardown crash in killProcess.
 beforeAll(async () => {
   // Set environment to test
   process.env.NODE_ENV = 'test';
+
+  const mongoUri = process.env.TEST_MONGODB_URI || process.env.MONGODB_URI;
+  if (!mongoUri) {
+    throw new Error('No MongoDB URI available - globalSetup did not run');
+  }
 
   // If already connected, disconnect first
   if (mongoose.connection.readyState !== 0) {
     await mongoose.connection.close();
   }
 
-  // Create MongoDB Memory Server
-  mongoServer = await MongoMemoryServer.create();
-  const mongoUri = mongoServer.getUri();
-  process.env.TEST_MONGODB_URI = mongoUri;
-
-  // Ensure only one connection
-  if (mongoose.connection.readyState === 0) {
-    await mongoose.connect(mongoUri, {
-      autoIndex: true,
-      serverSelectionTimeoutMS: 5000
-    });
-  }
+  await mongoose.connect(mongoUri, {
+    autoIndex: true,
+    serverSelectionTimeoutMS: 5000
+  });
 });
 
 afterAll(async () => {
-  // Disconnect if still connected
+  // Disconnect this worker's mongoose client. The shared in-memory server is
+  // stopped by jest globalTeardown, not here.
   if (mongoose.connection.readyState !== 0) {
     await mongoose.connection.close();
-  }
-
-  // Stop MongoDB Memory Server
-  if (mongoServer) {
-    await mongoServer.stop();
   }
 });
 


### PR DESCRIPTION
Bumps base image to node:26-alpine (build + runtime stages) and CI setup-node node-version to 26 across build.yml and security-scan.yml.

CI build-and-push validates the node:26 image (authoritative Node-26 check, since local node is 24).

Supersedes #182 (Dependabot node 25->26-alpine).

Local sanity (node 24, code-regression check only):
- npx tsc --noEmit: clean (exit 0)
- TEST_MODE=memory npx jest --runInBand --testPathIgnorePatterns=cross-service: 56 suites, 981 tests passed, 0 failures