### PR TITLE
Cap parsed dimensions at a physical ceiling to reject absurd values

### DIFF
--- a/src/utils/parseDimensions.ts
+++ b/src/utils/parseDimensions.ts
@@ -42,6 +42,14 @@ const DIMENSION_TOKEN = /([a-z]{1,12})\s*=\s*(\d+(?:\.\d+)?)\s*(mm|cm|in(?:ch(?:
 const SCALE_PATTERN = /(\d{1,4}\/\d{1,4})/;
 
 /**
+ * Physical sanity ceiling in millimeters. Nothing real is taller than this — a
+ * 1/1-scale figure is ~1700mm, so 2500mm leaves ample margin. Any parsed
+ * measurement above it is dropped: defense-in-depth so a malformed or
+ * concatenated value (e.g. the old 250210470 dimension bug) can never be stored.
+ */
+const MAX_DIMENSION_MM = 2500;
+
+/**
  * Convert a measurement to millimeters based on its unit label. Unknown or
  * absent units are assumed to already be millimeters (MFC's overwhelming
  * default). Rounds to 2 decimals so unit conversion does not introduce
@@ -80,7 +88,11 @@ export function parseDimensionsString(raw: string): IDimensions | null {
     if (!field || result[field] !== undefined) {
       continue;
     }
-    result[field] = toMillimeters(parseFloat(match[2]), match[3]);
+    const mm = toMillimeters(parseFloat(match[2]), match[3]);
+    if (mm > MAX_DIMENSION_MM) {
+      continue; // physically impossible — drop it rather than store garbage
+    }
+    result[field] = mm;
   }
 
   // Extract scale from patterns like 1/6, 1/7, 1/8.

--- a/tests/utils/parseDimensions.test.ts
+++ b/tests/utils/parseDimensions.test.ts
@@ -132,4 +132,35 @@ describe('parseDimensionsString', () => {
       expect(result).toBeNull();
     });
   });
+
+  // Defense-in-depth: even if malformed/concatenated data reaches the parser,
+  // physically impossible measurements must never be stored. Nothing real is
+  // taller than ~2500mm (a 1/1 figure is ~1700mm; margin above that).
+  describe('sanity cap on absurd measurements', () => {
+    it('should drop an absurd field but keep the sane ones', () => {
+      const result = parseDimensionsString('W=250mm, H=660580570mm');
+      expect(result).toEqual({ widthMm: 250 });
+      expect(result?.heightMm).toBeUndefined();
+    });
+
+    it('should reject a fully concatenated value (the original dimension bug)', () => {
+      const result = parseDimensionsString('H=250210470mm');
+      expect(result).toBeNull();
+    });
+
+    it('should drop any dimension over the ~2500mm ceiling', () => {
+      expect(parseDimensionsString('H=3000mm')).toBeNull();
+      expect(parseDimensionsString('W=9000mm, D=8000mm')).toBeNull();
+    });
+
+    it('should keep a legitimate 1/1-scale height (~1700mm)', () => {
+      const result = parseDimensionsString('H=1700mm');
+      expect(result).toEqual({ heightMm: 1700 });
+    });
+
+    it('should still keep scale even if a measurement is capped away', () => {
+      const result = parseDimensionsString('1/6, H=999999mm');
+      expect(result).toEqual({ scaledHeight: '1/6' });
+    });
+  });
 });


### PR DESCRIPTION
Adds a MAX_DIMENSION_MM (2500) sanity cap that drops physically-absurd parsed dimensions arising from scraper-corrupted concatenated values. 28/28 tests, 100% coverage on the parser.