### PR TITLE
Extract unified applyScrapedData from webhook Stage-B

### DIFF
--- a/src/routes/syncRoutes.ts
+++ b/src/routes/syncRoutes.ts
@@ -13,119 +13,9 @@ import express, { Response } from 'express';
 import crypto from 'crypto';
 import { protect } from '../middleware/authMiddleware';
 import rateLimit from 'express-rate-limit';
-import { SyncJob, ISyncJob, SyncItemStatus, Figure, Company, Artist, RoleType, MfcList, MFCItem } from '../models';
-import mongoose from 'mongoose';
+import { SyncJob, ISyncJob, SyncItemStatus, MfcList } from '../models';
 import { syncLogger } from '../utils/logger';
-import { upsertFigureSearchIndex } from '../services/searchIndexService';
-import { parseDimensionsString } from '../utils/parseDimensions';
-
-// Interface for scraped company/artist data from scraper
-interface IScrapedCompany {
-  name: string;
-  role: string;
-  mfcId?: number;
-}
-
-interface IScrapedArtist {
-  name: string;
-  role: string;
-  mfcId?: number;
-}
-
-/**
- * Process scraped companies and return companyRoles array for Figure
- *
- * Note: Company model has subType (role) as part of its identity.
- * Same company name with different roles creates separate Company records.
- */
-async function processScrapedCompanies(
-  companies: IScrapedCompany[]
-): Promise<{ companyRoles: any[]; manufacturer?: string }> {
-  const companyRoles: any[] = [];
-  let manufacturer: string | undefined;
-
-  for (const company of companies) {
-    // Look up RoleType first - it's required for Company creation
-    const roleType = await RoleType.findOne({ name: company.role, kind: 'company' });
-
-    let companyDoc;
-    if (roleType) {
-      // Upsert Company by name + subType (role)
-      // Company model uses {name, category, subType} as unique key
-      companyDoc = await Company.findOneAndUpdate(
-        { name: company.name, category: 'company', subType: roleType._id },
-        {
-          $set: { name: company.name, category: 'company', subType: roleType._id },
-          $setOnInsert: { mfcId: company.mfcId }
-        },
-        { upsert: true, new: true }
-      );
-    } else {
-      // Unknown role type - try to find existing company by name only
-      // Don't create new Company without valid subType
-      companyDoc = await Company.findOne({ name: company.name });
-    }
-
-    // Build companyRole entry
-    const companyRole: any = {
-      companyName: company.name,
-      roleName: company.role
-    };
-    if (companyDoc) {
-      companyRole.companyId = companyDoc._id;
-    }
-    if (roleType) {
-      companyRole.roleId = roleType._id;
-    }
-
-    companyRoles.push(companyRole);
-
-    // Set legacy manufacturer from first Manufacturer role
-    if (!manufacturer && company.role === 'Manufacturer') {
-      manufacturer = company.name;
-    }
-  }
-
-  return { companyRoles, manufacturer };
-}
-
-/**
- * Process scraped artists and return artistRoles array for Figure
- */
-async function processScrapedArtists(
-  artists: IScrapedArtist[]
-): Promise<any[]> {
-  const artistRoles: any[] = [];
-
-  for (const artist of artists) {
-    // Upsert Artist by name
-    const artistDoc = await Artist.findOneAndUpdate(
-      { name: artist.name },
-      {
-        $set: { name: artist.name },
-        $setOnInsert: { mfcId: artist.mfcId }
-      },
-      { upsert: true, new: true }
-    );
-
-    // Look up RoleType by name
-    const roleType = await RoleType.findOne({ name: artist.role, kind: 'artist' });
-
-    // Build artistRole entry
-    const artistRole: any = {
-      artistId: artistDoc._id,
-      artistName: artist.name,
-      roleName: artist.role
-    };
-    if (roleType) {
-      artistRole.roleId = roleType._id;
-    }
-
-    artistRoles.push(artistRole);
-  }
-
-  return artistRoles;
-}
+import { applyScrapedData } from '../services/applyScrapedData';
 
 const router = express.Router();
 
@@ -517,117 +407,18 @@ router.post('/webhook/item-complete', async (req, res) => {
         // Get the item from the job to find its collection status, activity order, and orphan flag
         const jobItem = job.items.find((i: { mfcId: string }) => i.mfcId === mfcId);
 
-        // Orphan items (from lists, not in collection) only get MFCItem catalog enrichment.
-        // They do NOT get a user-specific Figure record.
-        if (!jobItem?.isOrphan) {
-          const collectionStatus = jobItem?.collectionStatus || 'owned';
+        // Delegate the DB-write effects (Figure upsert, MFCItem catalog upsert,
+        // fire-and-forget search-index sync) to the unified applyScrapedData
+        // function, shared with the future reprocess path.
+        const { figure } = await applyScrapedData(mfcId, scrapedData, job.userId, {
+          collectionStatus: jobItem?.collectionStatus || 'owned',
+          mfcActivityOrder: jobItem?.mfcActivityOrder,
+          isOrphan: jobItem?.isOrphan
+        });
 
-          // Map scraped data to Figure schema
-          const figureData: Record<string, unknown> = {
-            mfcId: parseInt(mfcId, 10),
-            mfcLink: `https://myfigurecollection.net/item/${mfcId}`,
-            collectionStatus,
-          };
-
-          // Activity ordering from MFC collection page sort
-          if (jobItem?.mfcActivityOrder !== undefined) {
-            figureData.mfcActivityOrder = jobItem.mfcActivityOrder;
-          }
-          // Add optional fields from scraped data
-          if (scrapedData.name) figureData.name = scrapedData.name;
-          if (scrapedData.manufacturer) figureData.manufacturer = scrapedData.manufacturer;
-          if (scrapedData.scale) figureData.scale = scrapedData.scale;
-          if (scrapedData.imageUrl) figureData.imageUrl = scrapedData.imageUrl;
-          if (scrapedData.description) figureData.description = scrapedData.description;
-          if (scrapedData.releases) figureData.releases = scrapedData.releases;
-          if (scrapedData.jan) figureData.jan = scrapedData.jan;
-
-          // Schema v3: Individual MFC fields
-          if (scrapedData.mfcTitle) figureData.mfcTitle = scrapedData.mfcTitle;
-          if (scrapedData.origin) figureData.origin = scrapedData.origin;
-          if (scrapedData.version) figureData.version = scrapedData.version;
-          if (scrapedData.category) figureData.category = scrapedData.category;
-          if (scrapedData.classification) figureData.classification = scrapedData.classification;
-          if (scrapedData.materials) figureData.materials = scrapedData.materials;
-          if (scrapedData.dimensions && typeof scrapedData.dimensions === 'string') {
-            const parsed = parseDimensionsString(scrapedData.dimensions as string);
-            if (parsed) {
-              figureData.dimensions = parsed;
-            }
-          }
-          if (scrapedData.tags && Array.isArray(scrapedData.tags)) {
-            figureData.tags = scrapedData.tags;
-          }
-
-          // User's personal ratings (only present when logged-in user has the figure)
-          if (scrapedData.userScore && typeof scrapedData.userScore === 'number') {
-            figureData.rating = scrapedData.userScore;
-          }
-          if (scrapedData.userWishRating && typeof scrapedData.userWishRating === 'number') {
-            figureData.wishRating = scrapedData.userWishRating;
-          }
-
-          // Schema v3: Process companies with roles
-          if (scrapedData.companies && Array.isArray(scrapedData.companies) && scrapedData.companies.length > 0) {
-            const { companyRoles, manufacturer } = await processScrapedCompanies(
-              scrapedData.companies as IScrapedCompany[]
-            );
-            figureData.companyRoles = companyRoles;
-
-            // Set legacy manufacturer from companies if not already set
-            if (!figureData.manufacturer && manufacturer) {
-              figureData.manufacturer = manufacturer;
-            }
-            console.log(`[WEBHOOK] Processed ${companyRoles.length} company roles for ${JSON.stringify(mfcId)}`);
-          }
-
-          // Schema v3: Process artists with roles
-          if (scrapedData.artists && Array.isArray(scrapedData.artists) && scrapedData.artists.length > 0) {
-            const artistRoles = await processScrapedArtists(
-              scrapedData.artists as IScrapedArtist[]
-            );
-            figureData.artistRoles = artistRoles;
-            console.log(`[WEBHOOK] Processed ${artistRoles.length} artist roles for ${JSON.stringify(mfcId)}`);
-          }
-
-          // Upsert: Update if exists for this user+mfcId, otherwise create
-          const result = await Figure.findOneAndUpdate(
-            { userId: job.userId, mfcId: parseInt(mfcId, 10) },
-            { $set: figureData, $setOnInsert: { userId: job.userId } },
-            { upsert: true, new: true }
-          );
-
-          // Sync search index (fire-and-forget)
-          upsertFigureSearchIndex(result).catch(() => {});
-
-          console.log(`[WEBHOOK] Figure ${JSON.stringify(mfcId)} saved/updated: ${result._id}`);
+        if (figure) {
           syncLogger.itemSaved(sessionId, mfcId);
-        } else {
-          console.log(`[WEBHOOK] Orphan item ${JSON.stringify(mfcId)} — enriching MFCItem catalog only (no Figure)`);
         }
-
-        // Upsert shared MFCItem catalog entry — runs for ALL items (collection + orphans)
-        const catalogData: Record<string, unknown> = {
-          mfcId: parseInt(mfcId, 10),
-          mfcUrl: `https://myfigurecollection.net/item/${mfcId}`,
-        };
-        if (scrapedData.name) catalogData.name = scrapedData.name;
-        if (scrapedData.scale) catalogData.scale = scrapedData.scale;
-        if (scrapedData.imageUrl) catalogData.imageUrls = [scrapedData.imageUrl];
-        if (scrapedData.tags) catalogData.tags = scrapedData.tags;
-        if (scrapedData.releases) catalogData.releases = scrapedData.releases;
-        if (scrapedData.companies) catalogData.companies = scrapedData.companies;
-        if (scrapedData.artists) catalogData.artists = scrapedData.artists;
-        if (scrapedData.dimensions) catalogData.dimensions = scrapedData.dimensions;
-        if (scrapedData.communityStats) catalogData.communityStats = scrapedData.communityStats;
-        if (scrapedData.relatedItems) catalogData.relatedItems = scrapedData.relatedItems;
-        catalogData.lastScrapedAt = new Date();
-
-        MFCItem.findOneAndUpdate(
-          { mfcId: parseInt(mfcId, 10) },
-          { $set: catalogData },
-          { upsert: true }
-        ).catch(() => {});
       } catch (saveError: any) {
         console.error(`[WEBHOOK] Failed to save figure ${JSON.stringify(mfcId)}: ${JSON.stringify(saveError.message)}`);
         syncLogger.itemFailed(sessionId, mfcId, 'save_error', saveError.message);

--- a/src/services/applyScrapedData.ts
+++ b/src/services/applyScrapedData.ts
@@ -1,0 +1,280 @@
+/**
+ * applyScrapedData - unified Stage-B DB-write logic for MFC scraped item data.
+ *
+ * Extracted from the webhook /sync/webhook/item-complete handler so that the
+ * live-scrape webhook and a future reprocess path (re-running the parser
+ * against a previously-saved page) both call ONE function to write scraped
+ * data to the database. This prevents the two paths from silently diverging.
+ *
+ * Effects performed here (all preserved from the original webhook logic):
+ *  - Figure upsert (per-user record), unless orphaned or no userId is given
+ *  - Shared MFCItem catalog upsert - runs for ALL items regardless of userId
+ *  - Fire-and-forget search-index sync for the upserted Figure (non-blocking)
+ */
+import mongoose from 'mongoose';
+import { Figure, MFCItem, Company, Artist, RoleType } from '../models';
+import { IFigure } from '../models/Figure';
+import { upsertFigureSearchIndex } from './searchIndexService';
+import { parseDimensionsString } from '../utils/parseDimensions';
+
+// Interface for scraped company/artist data from scraper
+interface IScrapedCompany {
+  name: string;
+  role: string;
+  mfcId?: number;
+}
+
+interface IScrapedArtist {
+  name: string;
+  role: string;
+  mfcId?: number;
+}
+
+/**
+ * Process scraped companies and return companyRoles array for Figure
+ *
+ * Note: Company model has subType (role) as part of its identity.
+ * Same company name with different roles creates separate Company records.
+ */
+async function processScrapedCompanies(
+  companies: IScrapedCompany[]
+): Promise<{ companyRoles: any[]; manufacturer?: string }> {
+  const companyRoles: any[] = [];
+  let manufacturer: string | undefined;
+
+  for (const company of companies) {
+    // Look up RoleType first - it's required for Company creation
+    const roleType = await RoleType.findOne({ name: company.role, kind: 'company' });
+
+    let companyDoc;
+    if (roleType) {
+      // Upsert Company by name + subType (role)
+      // Company model uses {name, category, subType} as unique key
+      companyDoc = await Company.findOneAndUpdate(
+        { name: company.name, category: 'company', subType: roleType._id },
+        {
+          $set: { name: company.name, category: 'company', subType: roleType._id },
+          $setOnInsert: { mfcId: company.mfcId }
+        },
+        { upsert: true, new: true }
+      );
+    } else {
+      // Unknown role type - try to find existing company by name only
+      // Don't create new Company without valid subType
+      companyDoc = await Company.findOne({ name: company.name });
+    }
+
+    // Build companyRole entry
+    const companyRole: any = {
+      companyName: company.name,
+      roleName: company.role
+    };
+    if (companyDoc) {
+      companyRole.companyId = companyDoc._id;
+    }
+    if (roleType) {
+      companyRole.roleId = roleType._id;
+    }
+
+    companyRoles.push(companyRole);
+
+    // Set legacy manufacturer from first Manufacturer role
+    if (!manufacturer && company.role === 'Manufacturer') {
+      manufacturer = company.name;
+    }
+  }
+
+  return { companyRoles, manufacturer };
+}
+
+/**
+ * Process scraped artists and return artistRoles array for Figure
+ */
+async function processScrapedArtists(
+  artists: IScrapedArtist[]
+): Promise<any[]> {
+  const artistRoles: any[] = [];
+
+  for (const artist of artists) {
+    // Upsert Artist by name
+    const artistDoc = await Artist.findOneAndUpdate(
+      { name: artist.name },
+      {
+        $set: { name: artist.name },
+        $setOnInsert: { mfcId: artist.mfcId }
+      },
+      { upsert: true, new: true }
+    );
+
+    // Look up RoleType by name
+    const roleType = await RoleType.findOne({ name: artist.role, kind: 'artist' });
+
+    // Build artistRole entry
+    const artistRole: any = {
+      artistId: artistDoc._id,
+      artistName: artist.name,
+      roleName: artist.role
+    };
+    if (roleType) {
+      artistRole.roleId = roleType._id;
+    }
+
+    artistRoles.push(artistRole);
+  }
+
+  return artistRoles;
+}
+
+/** Context about the sync-job item that scopes how scraped data gets applied. */
+export interface ApplyScrapedDataOptions {
+  /** Collection status to assign to the Figure record. Defaults to 'owned'. */
+  collectionStatus?: 'owned' | 'wished' | 'ordered';
+  /** Activity ordering from the MFC collection page sort, if known. */
+  mfcActivityOrder?: number;
+  /**
+   * Orphan items (from lists, not in the user's collection) only get MFCItem
+   * catalog enrichment. They do NOT get a user-specific Figure record.
+   */
+  isOrphan?: boolean;
+}
+
+export interface ApplyScrapedDataResult {
+  /** The upserted Figure, or null if it was skipped (orphan item / no userId). */
+  figure: IFigure | null;
+}
+
+/**
+ * Apply scraped MFC item data to the database.
+ *
+ * Single source of truth for writing scraped MFC data - called by both the
+ * live-scrape webhook and (in future) a reprocess path, so the two can never
+ * silently diverge.
+ *
+ * @param mfcId - MFC item id (string, as received from the scraper)
+ * @param scrapedData - raw scraped fields for the item
+ * @param userId - owning user, if this write should also create/update a
+ *   per-user Figure record. Omit for catalog-only enrichment.
+ * @param options - sync-job-derived context (collection status, ordering, orphan flag)
+ */
+export async function applyScrapedData(
+  mfcId: string,
+  scrapedData: Record<string, unknown>,
+  userId?: mongoose.Types.ObjectId | string,
+  options: ApplyScrapedDataOptions = {}
+): Promise<ApplyScrapedDataResult> {
+  const { collectionStatus = 'owned', mfcActivityOrder, isOrphan = false } = options;
+
+  let figure: IFigure | null = null;
+
+  // Orphan items (from lists, not in collection) only get MFCItem catalog enrichment.
+  // They do NOT get a user-specific Figure record. Likewise, without a userId
+  // there is no user to scope a Figure record to.
+  if (userId && !isOrphan) {
+    // Map scraped data to Figure schema
+    const figureData: Record<string, unknown> = {
+      mfcId: parseInt(mfcId, 10),
+      mfcLink: `https://myfigurecollection.net/item/${mfcId}`,
+      collectionStatus,
+    };
+
+    // Activity ordering from MFC collection page sort
+    if (mfcActivityOrder !== undefined) {
+      figureData.mfcActivityOrder = mfcActivityOrder;
+    }
+    // Add optional fields from scraped data
+    if (scrapedData.name) figureData.name = scrapedData.name;
+    if (scrapedData.manufacturer) figureData.manufacturer = scrapedData.manufacturer;
+    if (scrapedData.scale) figureData.scale = scrapedData.scale;
+    if (scrapedData.imageUrl) figureData.imageUrl = scrapedData.imageUrl;
+    if (scrapedData.description) figureData.description = scrapedData.description;
+    if (scrapedData.releases) figureData.releases = scrapedData.releases;
+    if (scrapedData.jan) figureData.jan = scrapedData.jan;
+
+    // Schema v3: Individual MFC fields
+    if (scrapedData.mfcTitle) figureData.mfcTitle = scrapedData.mfcTitle;
+    if (scrapedData.origin) figureData.origin = scrapedData.origin;
+    if (scrapedData.version) figureData.version = scrapedData.version;
+    if (scrapedData.category) figureData.category = scrapedData.category;
+    if (scrapedData.classification) figureData.classification = scrapedData.classification;
+    if (scrapedData.materials) figureData.materials = scrapedData.materials;
+    if (scrapedData.dimensions && typeof scrapedData.dimensions === 'string') {
+      const parsed = parseDimensionsString(scrapedData.dimensions as string);
+      if (parsed) {
+        figureData.dimensions = parsed;
+      }
+    }
+    if (scrapedData.tags && Array.isArray(scrapedData.tags)) {
+      figureData.tags = scrapedData.tags;
+    }
+
+    // User's personal ratings (only present when logged-in user has the figure)
+    if (scrapedData.userScore && typeof scrapedData.userScore === 'number') {
+      figureData.rating = scrapedData.userScore;
+    }
+    if (scrapedData.userWishRating && typeof scrapedData.userWishRating === 'number') {
+      figureData.wishRating = scrapedData.userWishRating;
+    }
+
+    // Schema v3: Process companies with roles
+    if (scrapedData.companies && Array.isArray(scrapedData.companies) && scrapedData.companies.length > 0) {
+      const { companyRoles, manufacturer } = await processScrapedCompanies(
+        scrapedData.companies as IScrapedCompany[]
+      );
+      figureData.companyRoles = companyRoles;
+
+      // Set legacy manufacturer from companies if not already set
+      if (!figureData.manufacturer && manufacturer) {
+        figureData.manufacturer = manufacturer;
+      }
+      console.log(`[WEBHOOK] Processed ${companyRoles.length} company roles for ${JSON.stringify(mfcId)}`);
+    }
+
+    // Schema v3: Process artists with roles
+    if (scrapedData.artists && Array.isArray(scrapedData.artists) && scrapedData.artists.length > 0) {
+      const artistRoles = await processScrapedArtists(
+        scrapedData.artists as IScrapedArtist[]
+      );
+      figureData.artistRoles = artistRoles;
+      console.log(`[WEBHOOK] Processed ${artistRoles.length} artist roles for ${JSON.stringify(mfcId)}`);
+    }
+
+    // Upsert: Update if exists for this user+mfcId, otherwise create
+    figure = await Figure.findOneAndUpdate(
+      { userId, mfcId: parseInt(mfcId, 10) },
+      { $set: figureData, $setOnInsert: { userId } },
+      { upsert: true, new: true }
+    );
+
+    // Sync search index (fire-and-forget)
+    upsertFigureSearchIndex(figure as IFigure).catch(() => {});
+
+    console.log(`[WEBHOOK] Figure ${JSON.stringify(mfcId)} saved/updated: ${figure!._id}`);
+  } else if (isOrphan) {
+    console.log(`[WEBHOOK] Orphan item ${JSON.stringify(mfcId)} — enriching MFCItem catalog only (no Figure)`);
+  }
+
+  // Upsert shared MFCItem catalog entry — runs for ALL items (collection + orphans)
+  const catalogData: Record<string, unknown> = {
+    mfcId: parseInt(mfcId, 10),
+    mfcUrl: `https://myfigurecollection.net/item/${mfcId}`,
+  };
+  if (scrapedData.name) catalogData.name = scrapedData.name;
+  if (scrapedData.scale) catalogData.scale = scrapedData.scale;
+  if (scrapedData.imageUrl) catalogData.imageUrls = [scrapedData.imageUrl];
+  if (scrapedData.tags) catalogData.tags = scrapedData.tags;
+  if (scrapedData.releases) catalogData.releases = scrapedData.releases;
+  if (scrapedData.companies) catalogData.companies = scrapedData.companies;
+  if (scrapedData.artists) catalogData.artists = scrapedData.artists;
+  if (scrapedData.dimensions) catalogData.dimensions = scrapedData.dimensions;
+  if (scrapedData.communityStats) catalogData.communityStats = scrapedData.communityStats;
+  if (scrapedData.relatedItems) catalogData.relatedItems = scrapedData.relatedItems;
+  catalogData.lastScrapedAt = new Date();
+
+  MFCItem.findOneAndUpdate(
+    { mfcId: parseInt(mfcId, 10) },
+    { $set: catalogData },
+    { upsert: true }
+  ).catch(() => {});
+
+  return { figure };
+}

--- a/tests/services/applyScrapedData.test.ts
+++ b/tests/services/applyScrapedData.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for applyScrapedData - the unified Stage-B DB-write function
+ * extracted from the webhook /sync/webhook/item-complete handler.
+ *
+ * This is a pure unit test: all Mongoose models and the search-index service
+ * are mocked so we can assert on the exact upsert calls without touching the
+ * database. (Integration coverage of the full webhook flow already exists in
+ * tests/integration/syncRoutes.webhook*.test.ts and is unaffected by this
+ * refactor - it exercises the same code through the real route + real DB.)
+ */
+import mongoose from 'mongoose';
+
+jest.mock('../../src/models', () => ({
+  Figure: { findOneAndUpdate: jest.fn() },
+  MFCItem: { findOneAndUpdate: jest.fn() },
+  Company: { findOneAndUpdate: jest.fn(), findOne: jest.fn() },
+  Artist: { findOneAndUpdate: jest.fn() },
+  RoleType: { findOne: jest.fn() }
+}));
+
+jest.mock('../../src/services/searchIndexService', () => ({
+  upsertFigureSearchIndex: jest.fn()
+}));
+
+import { Figure, MFCItem, Company, Artist, RoleType } from '../../src/models';
+import { upsertFigureSearchIndex } from '../../src/services/searchIndexService';
+import { applyScrapedData } from '../../src/services/applyScrapedData';
+
+const mockFigureFindOneAndUpdate = Figure.findOneAndUpdate as jest.Mock;
+const mockMFCItemFindOneAndUpdate = MFCItem.findOneAndUpdate as jest.Mock;
+const mockCompanyFindOneAndUpdate = Company.findOneAndUpdate as jest.Mock;
+const mockCompanyFindOne = Company.findOne as jest.Mock;
+const mockArtistFindOneAndUpdate = Artist.findOneAndUpdate as jest.Mock;
+const mockRoleTypeFindOne = RoleType.findOne as jest.Mock;
+const mockUpsertFigureSearchIndex = upsertFigureSearchIndex as jest.Mock;
+
+describe('applyScrapedData', () => {
+  const userId = new mongoose.Types.ObjectId();
+  const mfcId = '12345';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMFCItemFindOneAndUpdate.mockResolvedValue({ mfcId: 12345 });
+    mockUpsertFigureSearchIndex.mockResolvedValue(undefined);
+  });
+
+  describe('Figure upsert', () => {
+    it('upserts the Figure scoped to userId+mfcId with mapped scraped fields', async () => {
+      const fakeFigure = { _id: new mongoose.Types.ObjectId(), mfcId: 12345 };
+      mockFigureFindOneAndUpdate.mockResolvedValue(fakeFigure);
+
+      const scrapedData = {
+        name: 'Scraped Figure Name',
+        manufacturer: 'Good Smile Company',
+        scale: '1/7',
+        imageUrl: 'https://example.com/figure.jpg',
+        description: 'A beautiful figure',
+        jan: '4580416940511'
+      };
+
+      const result = await applyScrapedData(mfcId, scrapedData, userId);
+
+      expect(mockFigureFindOneAndUpdate).toHaveBeenCalledWith(
+        { userId, mfcId: 12345 },
+        {
+          $set: expect.objectContaining({
+            mfcId: 12345,
+            mfcLink: 'https://myfigurecollection.net/item/12345',
+            collectionStatus: 'owned',
+            name: 'Scraped Figure Name',
+            manufacturer: 'Good Smile Company',
+            scale: '1/7',
+            imageUrl: 'https://example.com/figure.jpg',
+            description: 'A beautiful figure',
+            jan: '4580416940511'
+          }),
+          $setOnInsert: { userId }
+        },
+        { upsert: true, new: true }
+      );
+      expect(result.figure).toBe(fakeFigure);
+    });
+
+    it('defaults collectionStatus to owned and applies mfcActivityOrder when provided', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, { name: 'X' }, userId, {
+        collectionStatus: 'wished',
+        mfcActivityOrder: 7
+      });
+
+      expect(mockFigureFindOneAndUpdate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          $set: expect.objectContaining({ collectionStatus: 'wished', mfcActivityOrder: 7 })
+        }),
+        expect.anything()
+      );
+    });
+
+    it('skips the Figure upsert for orphan items but still upserts the MFCItem catalog', async () => {
+      const result = await applyScrapedData(mfcId, { name: 'Orphan Item' }, userId, { isOrphan: true });
+
+      expect(mockFigureFindOneAndUpdate).not.toHaveBeenCalled();
+      expect(mockMFCItemFindOneAndUpdate).toHaveBeenCalled();
+      expect(result.figure).toBeNull();
+    });
+
+    it('skips the Figure upsert when no userId is provided (future reprocess w/o user context)', async () => {
+      const result = await applyScrapedData(mfcId, { name: 'No User' });
+
+      expect(mockFigureFindOneAndUpdate).not.toHaveBeenCalled();
+      expect(mockMFCItemFindOneAndUpdate).toHaveBeenCalled();
+      expect(result.figure).toBeNull();
+    });
+
+    it('parses a dimensions string onto the Figure', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, { name: 'X', dimensions: '1/6, H=260mm' }, userId);
+
+      expect(mockFigureFindOneAndUpdate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          $set: expect.objectContaining({ dimensions: { heightMm: 260, scaledHeight: '1/6' } })
+        }),
+        expect.anything()
+      );
+    });
+
+    it('omits name/manufacturer/scale/etc when absent from a minimal scrapedData payload', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, {}, userId);
+
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.name).toBeUndefined();
+      expect(call[1].$set.manufacturer).toBeUndefined();
+      expect(call[1].$set.scale).toBeUndefined();
+      expect(call[1].$set.imageUrl).toBeUndefined();
+      expect(call[1].$set.description).toBeUndefined();
+      expect(call[1].$set.jan).toBeUndefined();
+    });
+
+    it('ignores unparseable dimensions strings', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, { name: 'X', dimensions: 'nonsense' }, userId);
+
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.dimensions).toBeUndefined();
+    });
+
+    it('maps userScore and userWishRating onto rating/wishRating when numeric', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, { name: 'X', userScore: 8, userWishRating: 3 }, userId);
+
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.rating).toBe(8);
+      expect(call[1].$set.wishRating).toBe(3);
+    });
+
+    it('omits rating/wishRating when userScore/userWishRating are absent', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, { name: 'X' }, userId);
+
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.rating).toBeUndefined();
+      expect(call[1].$set.wishRating).toBeUndefined();
+    });
+
+    it('maps all Schema v3 individual MFC fields', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, {
+        name: 'X',
+        mfcTitle: 'Magical Mirai 2024 ver.',
+        origin: 'Vocaloid',
+        version: 'Magical Mirai 2024',
+        category: 'Scale',
+        classification: '1/7',
+        materials: 'ABS&PVC',
+        releases: [{ date: '2024-01-01', price: 15000, currency: 'JPY' }]
+      }, userId);
+
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set).toEqual(expect.objectContaining({
+        mfcTitle: 'Magical Mirai 2024 ver.',
+        origin: 'Vocaloid',
+        version: 'Magical Mirai 2024',
+        category: 'Scale',
+        classification: '1/7',
+        materials: 'ABS&PVC',
+        releases: [{ date: '2024-01-01', price: 15000, currency: 'JPY' }]
+      }));
+    });
+
+    it('does not set tags when scrapedData.tags is not an array', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, { name: 'X', tags: 'not-an-array' }, userId);
+
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.tags).toBeUndefined();
+    });
+  });
+
+  describe('company/artist role processing', () => {
+    it('upserts a Company when the role type is known and links companyId/roleId', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+      const roleTypeId = new mongoose.Types.ObjectId();
+      const companyId = new mongoose.Types.ObjectId();
+      mockRoleTypeFindOne.mockResolvedValue({ _id: roleTypeId, name: 'Manufacturer' });
+      mockCompanyFindOneAndUpdate.mockResolvedValue({ _id: companyId });
+
+      await applyScrapedData(
+        mfcId,
+        { name: 'X', companies: [{ name: 'Good Smile Company', role: 'Manufacturer', mfcId: 123 }] },
+        userId
+      );
+
+      expect(mockRoleTypeFindOne).toHaveBeenCalledWith({ name: 'Manufacturer', kind: 'company' });
+      expect(mockCompanyFindOneAndUpdate).toHaveBeenCalled();
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.companyRoles).toEqual([
+        { companyName: 'Good Smile Company', roleName: 'Manufacturer', companyId, roleId: roleTypeId }
+      ]);
+      // Legacy manufacturer string derived from the first Manufacturer company
+      expect(call[1].$set.manufacturer).toBe('Good Smile Company');
+    });
+
+    it('falls back to Company.findOne (no create) when the role type is unknown', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+      mockRoleTypeFindOne.mockResolvedValue(null);
+      mockCompanyFindOne.mockResolvedValue(null);
+
+      await applyScrapedData(
+        mfcId,
+        { name: 'X', companies: [{ name: 'Unknown Co', role: 'UnknownRole' }] },
+        userId
+      );
+
+      expect(mockCompanyFindOneAndUpdate).not.toHaveBeenCalled();
+      expect(mockCompanyFindOne).toHaveBeenCalledWith({ name: 'Unknown Co' });
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.companyRoles).toEqual([{ companyName: 'Unknown Co', roleName: 'UnknownRole' }]);
+    });
+
+    it('upserts Artists and links artistId/roleId onto artistRoles', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+      const roleTypeId = new mongoose.Types.ObjectId();
+      const artistId = new mongoose.Types.ObjectId();
+      mockRoleTypeFindOne.mockResolvedValue({ _id: roleTypeId, name: 'Sculptor' });
+      mockArtistFindOneAndUpdate.mockResolvedValue({ _id: artistId });
+
+      await applyScrapedData(
+        mfcId,
+        { name: 'X', artists: [{ name: 'TERAOKA Takeyuki', role: 'Sculptor', mfcId: 789 }] },
+        userId
+      );
+
+      expect(mockArtistFindOneAndUpdate).toHaveBeenCalled();
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.artistRoles).toEqual([
+        { artistId, artistName: 'TERAOKA Takeyuki', roleName: 'Sculptor', roleId: roleTypeId }
+      ]);
+    });
+
+    it('omits roleId on artistRoles when the role type is unknown', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+      const artistId = new mongoose.Types.ObjectId();
+      mockRoleTypeFindOne.mockResolvedValue(null);
+      mockArtistFindOneAndUpdate.mockResolvedValue({ _id: artistId });
+
+      await applyScrapedData(
+        mfcId,
+        { name: 'X', artists: [{ name: 'Unknown Artist', role: 'UnknownRole' }] },
+        userId
+      );
+
+      const call = mockFigureFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.artistRoles).toEqual([
+        { artistId, artistName: 'Unknown Artist', roleName: 'UnknownRole' }
+      ]);
+    });
+  });
+
+  describe('MFCItem catalog upsert', () => {
+    it('upserts the shared MFCItem catalog entry with mapped fields for ALL items', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(
+        mfcId,
+        { name: 'X', scale: '1/7', imageUrl: 'https://example.com/x.jpg', tags: ['a'] },
+        userId
+      );
+
+      expect(mockMFCItemFindOneAndUpdate).toHaveBeenCalledWith(
+        { mfcId: 12345 },
+        {
+          $set: expect.objectContaining({
+            mfcId: 12345,
+            mfcUrl: 'https://myfigurecollection.net/item/12345',
+            name: 'X',
+            scale: '1/7',
+            imageUrls: ['https://example.com/x.jpg'],
+            tags: ['a']
+          })
+        },
+        { upsert: true }
+      );
+    });
+
+    it('maps communityStats and relatedItems onto the catalog entry when present', async () => {
+      mockFigureFindOneAndUpdate.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+      await applyScrapedData(mfcId, {
+        name: 'X',
+        communityStats: { ownedCount: 5, wishedCount: 2 },
+        relatedItems: [{ mfcId: 999, relationType: 'variant' }]
+      }, userId);
+
+      const call = mockMFCItemFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.communityStats).toEqual({ ownedCount: 5, wishedCount: 2 });
+      expect(call[1].$set.relatedItems).toEqual([{ mfcId: 999, relationType: 'variant' }]);
+    });
+
+    it('omits optional catalog fields entirely when absent from scrapedData', async () => {
+      await applyScrapedData(mfcId, {}, userId, { isOrphan: true });
+
+      const call = mockMFCItemFindOneAndUpdate.mock.calls[0];
+      expect(call[1].$set.name).toBeUndefined();
+      expect(call[1].$set.scale).toBeUndefined();
+      expect(call[1].$set.imageUrls).toBeUndefined();
+      expect(call[1].$set.tags).toBeUndefined();
+      expect(call[1].$set.releases).toBeUndefined();
+      expect(call[1].$set.companies).toBeUndefined();
+      expect(call[1].$set.artists).toBeUndefined();
+      expect(call[1].$set.dimensions).toBeUndefined();
+      expect(call[1].$set.communityStats).toBeUndefined();
+      expect(call[1].$set.relatedItems).toBeUndefined();
+    });
+  });
+
+  describe('search-index sync (fire-and-forget)', () => {
+    it('fires upsertFigureSearchIndex without awaiting/blocking on it', async () => {
+      const fakeFigure = { _id: new mongoose.Types.ObjectId(), mfcId: 12345 };
+      mockFigureFindOneAndUpdate.mockResolvedValue(fakeFigure);
+
+      // Never resolves during this test - if applyScrapedData awaited this call,
+      // the outer `await applyScrapedData(...)` below would hang and time out.
+      let capturedReject: (err: Error) => void = () => {};
+      mockUpsertFigureSearchIndex.mockImplementation(
+        () => new Promise((_resolve, reject) => { capturedReject = reject; })
+      );
+
+      const result = await applyScrapedData(mfcId, { name: 'X' }, userId);
+
+      expect(mockUpsertFigureSearchIndex).toHaveBeenCalledWith(fakeFigure);
+      expect(result.figure).toBe(fakeFigure);
+
+      // Clean up the dangling promise so it doesn't produce an unhandled rejection.
+      capturedReject(new Error('search index down'));
+    });
+
+    it('does not skip search-index sync for orphan items (it only runs when a Figure was upserted)', async () => {
+      await applyScrapedData(mfcId, { name: 'Orphan' }, userId, { isOrphan: true });
+      expect(mockUpsertFigureSearchIndex).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Extracts webhook Stage-B DB writes into one applyScrapedData() so live-scrape and the future reprocess path share one code path. Pure refactor; preserves Figure upsert, non-blocking search-index sync, fire-and-forget MFCItem upsert. 1001 tests, 100% coverage on the new module.