### PR TITLE
Add image-manager client and nested displayMeta fields on Figure model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,14 @@ SCRAPER_SERVICE_URL=http://localhost:3080
 # SCRAPER_SERVICE_URL=http://scraper:3050
 # SCRAPER_SERVICE_URL=http://scraper-dev:3090
 
+# image-manager service (figure image matting + display metadata)
+# Local development
+IMAGE_MANAGER_URL=http://localhost:8000
+# Docker/Coolify deployment (must match service/network name)
+# IMAGE_MANAGER_URL=http://image-manager:8000
+# Optional service-to-service JWT sent as `Authorization: Bearer <token>`
+# IMAGE_MANAGER_SERVICE_TOKEN=your_service_token_here
+
 # Admin Bootstrap Token (optional)
 # Used for one-time admin privilege grant via POST /admin/bootstrap
 # Generate a secure random token: openssl rand -base64 32

--- a/src/models/Figure.ts
+++ b/src/models/Figure.ts
@@ -54,6 +54,31 @@ export interface IArtistRole {
   roleName?: string;
 }
 
+/**
+ * Horizontal ground-contact footprint of a matted figure image, measured from
+ * the matte's alpha channel. Mirrors fc-shared FigureContactBand field-for-field.
+ */
+export interface IFigureContactBand {
+  centerXFrac: number;
+  widthFrac: number;
+}
+
+/**
+ * Display + grounding metadata that the image-manager service PRODUCES and
+ * fc-mobile CONSUMES. Frozen cross-service contract — mirrors fc-shared
+ * FigureDisplayMeta exactly (nested object, all fields optional). Additive
+ * only: imageUrl remains the untouched source-image fallback.
+ */
+export interface IFigureDisplayMeta {
+  matted?: boolean;
+  matteImageId?: string;
+  matteVersionId?: string;
+  bottomMarginFrac?: number;
+  contactBand?: IFigureContactBand;
+  thumbhash?: string;
+  dominantColor?: string;
+}
+
 export interface IFigure extends Document {
   _id: mongoose.Types.ObjectId;
 
@@ -76,6 +101,9 @@ export interface IFigure extends Document {
   // Media
   imageUrl?: string;
   imageUrls?: string[];
+
+  // Display + grounding metadata (image-manager -> fc-mobile contract)
+  displayMeta?: IFigureDisplayMeta;
 
   // Releases (supports multiple releases/rereleases)
   releases?: IRelease[];
@@ -179,6 +207,28 @@ const ArtistRoleSchema = new Schema<IArtistRole>(
   { _id: false }
 );
 
+const ContactBandSchema = new Schema<IFigureContactBand>(
+  {
+    centerXFrac: { type: Number },
+    widthFrac: { type: Number }
+  },
+  { _id: false }
+);
+
+// Mirrors fc-shared FigureDisplayMeta: nested, all-optional, additive-only.
+const DisplayMetaSchema = new Schema<IFigureDisplayMeta>(
+  {
+    matted: { type: Boolean },
+    matteImageId: { type: String },
+    matteVersionId: { type: String },
+    bottomMarginFrac: { type: Number },
+    contactBand: { type: ContactBandSchema },
+    thumbhash: { type: String },
+    dominantColor: { type: String }
+  },
+  { _id: false }
+);
+
 const FigureSchema = new Schema<IFigure>(
   {
     // Core identification
@@ -201,6 +251,10 @@ const FigureSchema = new Schema<IFigure>(
     // Media
     imageUrl: { type: String },
     imageUrls: { type: [String], default: [] },
+
+    // Display + grounding metadata (image-manager -> fc-mobile contract).
+    // No default: stays undefined until image-manager populates it.
+    displayMeta: { type: DisplayMetaSchema },
 
     // Releases
     releases: { type: [ReleaseSchema], default: [] },

--- a/src/services/imageManagerClient.ts
+++ b/src/services/imageManagerClient.ts
@@ -1,0 +1,203 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import * as https from 'https';
+
+/**
+ * Typed HTTP client for the image-manager microservice.
+ *
+ * Scope note: this module is intentionally NOT wired into any route/controller
+ * yet. It exists purely as the typed client + tests for a later phase that
+ * will route figure images through image-manager for matting/derived metadata.
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+// Read env vars at call time (not module load) so tests can set/change them,
+// mirroring the SCRAPER_SERVICE_URL pattern in figureController.ts.
+const getImageManagerUrl = (): string =>
+  process.env.IMAGE_MANAGER_URL || 'http://localhost:8000'; // NOSONAR - internal service URL from env
+
+const getServiceToken = (): string | undefined => process.env.IMAGE_MANAGER_SERVICE_TOKEN;
+
+// Ingest just enqueues a background job, so a generous timeout absorbs network
+// hiccups without much cost. The poll GET is expected to be called repeatedly
+// (Phase-4 poller), so it fails fast instead of stacking up slow requests.
+const INGEST_TIMEOUT_MS = 15000;
+const POLL_TIMEOUT_MS = 5000;
+
+/**
+ * mTLS seam: today this just returns undefined, so axios falls back to its
+ * default HTTP(S) behavior. Once mTLS is wired up (later phase), this factory
+ * can construct an https.Agent loaded with a client cert/key/CA (paths from
+ * env vars) and every call site below picks it up automatically.
+ */
+const buildHttpsAgent = (): https.Agent | undefined => undefined;
+
+const buildHeaders = (): Record<string, string> => {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = getServiceToken();
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return headers;
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export type ImageManagerErrorKind = 'timeout' | 'network' | 'http' | 'unknown';
+
+export class ImageManagerClientError extends Error {
+  readonly kind: ImageManagerErrorKind;
+  readonly status?: number;
+
+  constructor(message: string, kind: ImageManagerErrorKind, status?: number) {
+    super(message);
+    this.name = 'ImageManagerClientError';
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+/** Classify any error thrown during a request and re-throw as ImageManagerClientError. Never lets a raw axios/network error escape. */
+const handleRequestError = (error: unknown): never => {
+  if (axios.isAxiosError(error)) {
+    if (error.code === 'ECONNABORTED') {
+      throw new ImageManagerClientError(`image-manager request timed out: ${error.message}`, 'timeout');
+    }
+    if (error.response) {
+      throw new ImageManagerClientError(
+        `image-manager returned HTTP ${error.response.status}`,
+        'http',
+        error.response.status
+      );
+    }
+    throw new ImageManagerClientError(`image-manager network error: ${error.message}`, 'network');
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  throw new ImageManagerClientError(`image-manager client error: ${message}`, 'unknown');
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GalleryImageInput {
+  url: string;
+  position?: number;
+  caption?: string;
+}
+
+interface GalleryImageWirePayload {
+  url: string;
+  position: number;
+  caption?: string;
+}
+
+export interface IngestGalleryImagesResponse {
+  figureId: string;
+  imagesQueued: number;
+  duplicatesSkipped: number;
+}
+
+export interface GalleryImage {
+  id: number;
+  url: string;
+  position: number;
+  caption?: string;
+}
+
+export interface GetGalleryResponse {
+  figureId: string;
+  images: GalleryImage[];
+  count: number;
+}
+
+const isValidIngestResponse = (data: any): data is IngestGalleryImagesResponse =>
+  !!data &&
+  typeof data.figureId === 'string' &&
+  typeof data.imagesQueued === 'number' &&
+  typeof data.duplicatesSkipped === 'number';
+
+const isValidGetGalleryResponse = (data: any): data is GetGalleryResponse =>
+  !!data && typeof data.figureId === 'string' && Array.isArray(data.images) && typeof data.count === 'number';
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * POST {IMAGE_MANAGER_URL}/galleries/ingest — queues the given images for
+ * matting/processing. The server's `position` field is required, so a caller
+ * omitting `position` gets it defaulted to the image's array index here.
+ */
+export async function ingestGalleryImages(
+  figureId: string,
+  images: GalleryImageInput[]
+): Promise<IngestGalleryImagesResponse> {
+  const payload = {
+    figureId,
+    images: images.map((image, index): GalleryImageWirePayload => {
+      const wireImage: GalleryImageWirePayload = {
+        url: image.url,
+        position: image.position ?? index
+      };
+      if (image.caption !== undefined) {
+        wireImage.caption = image.caption;
+      }
+      return wireImage;
+    })
+  };
+
+  const config: AxiosRequestConfig = {
+    headers: buildHeaders(),
+    timeout: INGEST_TIMEOUT_MS,
+    httpsAgent: buildHttpsAgent()
+  };
+
+  let response: AxiosResponse<IngestGalleryImagesResponse>;
+  try {
+    response = await axios.post<IngestGalleryImagesResponse>(
+      `${getImageManagerUrl()}/galleries/ingest`,
+      payload,
+      config
+    );
+  } catch (error) {
+    return handleRequestError(error);
+  }
+
+  if (!isValidIngestResponse(response.data)) {
+    throw new ImageManagerClientError('image-manager returned a malformed ingest response', 'unknown');
+  }
+
+  return response.data;
+}
+
+/**
+ * GET {IMAGE_MANAGER_URL}/galleries/{figureId} — fetches matted gallery
+ * contents. Ingest is async, so a Phase-4 poller will call this repeatedly
+ * until processing completes.
+ */
+export async function getGallery(figureId: string): Promise<GetGalleryResponse> {
+  const config: AxiosRequestConfig = {
+    headers: buildHeaders(),
+    timeout: POLL_TIMEOUT_MS,
+    httpsAgent: buildHttpsAgent()
+  };
+
+  let response: AxiosResponse<GetGalleryResponse>;
+  try {
+    response = await axios.get<GetGalleryResponse>(`${getImageManagerUrl()}/galleries/${figureId}`, config);
+  } catch (error) {
+    return handleRequestError(error);
+  }
+
+  if (!isValidGetGalleryResponse(response.data)) {
+    throw new ImageManagerClientError('image-manager returned a malformed gallery response', 'unknown');
+  }
+
+  return response.data;
+}

--- a/tests/models/Figure.test.ts
+++ b/tests/models/Figure.test.ts
@@ -355,4 +355,75 @@ describe('Figure Model', () => {
       expect(figures[2].name).toBe('Megumin');
     });
   });
+
+  describe('displayMeta (image-manager -> fc-mobile contract)', () => {
+    // Mirrors fc-shared FigureDisplayMeta exactly: nested object, all fields
+    // optional, contactBand a nested {centerXFrac, widthFrac}. Additive only —
+    // imageUrl remains the untouched fallback.
+    it('round-trips a fully-populated nested displayMeta through the database', async () => {
+      const figure = new Figure({
+        name: 'Hatsune Miku',
+        manufacturer: 'Good Smile Company',
+        userId: testUserId,
+        imageUrl: 'https://example.com/source.jpg',
+        displayMeta: {
+          matted: true,
+          matteImageId: 'img-abc123',
+          matteVersionId: 'v-7',
+          bottomMarginFrac: 0.0421,
+          contactBand: { centerXFrac: 0.52, widthFrac: 0.31 },
+          thumbhash: 'L6Pj0^jE.AyE_3t7t7R**0o#DgR4',
+          dominantColor: '#8899AA'
+        }
+      });
+      await figure.save();
+
+      const reloaded = await Figure.findById(figure._id);
+      expect(reloaded?.displayMeta).toBeDefined();
+      expect(reloaded?.displayMeta?.matted).toBe(true);
+      expect(reloaded?.displayMeta?.matteImageId).toBe('img-abc123');
+      expect(reloaded?.displayMeta?.matteVersionId).toBe('v-7');
+      expect(reloaded?.displayMeta?.bottomMarginFrac).toBeCloseTo(0.0421);
+      expect(reloaded?.displayMeta?.contactBand?.centerXFrac).toBeCloseTo(0.52);
+      expect(reloaded?.displayMeta?.contactBand?.widthFrac).toBeCloseTo(0.31);
+      expect(reloaded?.displayMeta?.thumbhash).toBe('L6Pj0^jE.AyE_3t7t7R**0o#DgR4');
+      expect(reloaded?.displayMeta?.dominantColor).toBe('#8899AA');
+      // Additive: the original source image URL is preserved untouched.
+      expect(reloaded?.imageUrl).toBe('https://example.com/source.jpg');
+    });
+
+    it('persists a partial displayMeta, leaving unset fields undefined (each field independently optional)', async () => {
+      const figure = new Figure({
+        name: 'Kagamine Rin',
+        manufacturer: 'Good Smile Company',
+        userId: testUserId,
+        displayMeta: {
+          thumbhash: 'L6Pj0^jE.AyE_3t7t7R**0o#DgR4',
+          dominantColor: '#112233'
+        }
+      });
+      await figure.save();
+
+      const reloaded = await Figure.findById(figure._id);
+      expect(reloaded?.displayMeta?.thumbhash).toBe('L6Pj0^jE.AyE_3t7t7R**0o#DgR4');
+      expect(reloaded?.displayMeta?.dominantColor).toBe('#112233');
+      expect(reloaded?.displayMeta?.matted).toBeUndefined();
+      expect(reloaded?.displayMeta?.matteImageId).toBeUndefined();
+      expect(reloaded?.displayMeta?.contactBand).toBeUndefined();
+    });
+
+    it('saves a Figure with no displayMeta at all, preserving imageUrl (backward compatible)', async () => {
+      const figure = new Figure({
+        name: 'Megumin',
+        manufacturer: 'Good Smile Company',
+        userId: testUserId,
+        imageUrl: 'https://example.com/legacy.jpg'
+      });
+      await figure.save();
+
+      const reloaded = await Figure.findById(figure._id);
+      expect(reloaded?.displayMeta).toBeUndefined();
+      expect(reloaded?.imageUrl).toBe('https://example.com/legacy.jpg');
+    });
+  });
 });

--- a/tests/services/imageManagerClient.test.ts
+++ b/tests/services/imageManagerClient.test.ts
@@ -1,0 +1,304 @@
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Import after mocking axios so the module under test picks up the mock.
+import {
+  ingestGalleryImages,
+  getGallery,
+  ImageManagerClientError
+} from '../../src/services/imageManagerClient';
+
+const ORIGINAL_ENV = process.env;
+
+describe('imageManagerClient', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.IMAGE_MANAGER_URL;
+    delete process.env.IMAGE_MANAGER_SERVICE_TOKEN;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('ingestGalleryImages', () => {
+    it('POSTs to /galleries/ingest with the default URL when IMAGE_MANAGER_URL is unset', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', imagesQueued: 1, duplicatesSkipped: 0 }
+      });
+
+      await ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }]);
+
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+      const [url] = mockedAxios.post.mock.calls[0];
+      expect(url).toMatch(/^http:\/\/localhost:\d+\/galleries\/ingest$/);
+    });
+
+    it('POSTs to {IMAGE_MANAGER_URL}/galleries/ingest when the env var is set', async () => {
+      process.env.IMAGE_MANAGER_URL = 'http://image-manager:8000';
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', imagesQueued: 1, duplicatesSkipped: 0 }
+      });
+
+      await ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }]);
+
+      const [url] = mockedAxios.post.mock.calls[0];
+      expect(url).toBe('http://image-manager:8000/galleries/ingest');
+    });
+
+    it('builds the wire payload with camelCase fields, defaulting missing position to array index', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', imagesQueued: 3, duplicatesSkipped: 0 }
+      });
+
+      await ingestGalleryImages('fig-1', [
+        { url: 'https://example.com/a.jpg' }, // no position -> should default to 0
+        { url: 'https://example.com/b.jpg', position: 5, caption: 'front view' },
+        { url: 'https://example.com/c.jpg' } // no position -> should default to 2
+      ]);
+
+      const [, body] = mockedAxios.post.mock.calls[0];
+      expect(body).toEqual({
+        figureId: 'fig-1',
+        images: [
+          { url: 'https://example.com/a.jpg', position: 0 },
+          { url: 'https://example.com/b.jpg', position: 5, caption: 'front view' },
+          { url: 'https://example.com/c.jpg', position: 2 }
+        ]
+      });
+    });
+
+    it('sends Content-Type header and a sane timeout, and omits Authorization when no token configured', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', imagesQueued: 1, duplicatesSkipped: 0 }
+      });
+
+      await ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }]);
+
+      const [, , config] = mockedAxios.post.mock.calls[0];
+      expect(config?.headers).toMatchObject({ 'Content-Type': 'application/json' });
+      expect(config?.headers).not.toHaveProperty('Authorization');
+      expect(typeof config?.timeout).toBe('number');
+      expect(config?.timeout).toBeGreaterThan(0);
+    });
+
+    it('sends an Authorization Bearer header when IMAGE_MANAGER_SERVICE_TOKEN is configured', async () => {
+      process.env.IMAGE_MANAGER_SERVICE_TOKEN = 'service-jwt-abc';
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', imagesQueued: 1, duplicatesSkipped: 0 }
+      });
+
+      await ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }]);
+
+      const [, , config] = mockedAxios.post.mock.calls[0];
+      expect(config?.headers).toMatchObject({ Authorization: 'Bearer service-jwt-abc' });
+    });
+
+    it('returns the parsed {figureId, imagesQueued, duplicatesSkipped} response', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-9', imagesQueued: 2, duplicatesSkipped: 1 }
+      });
+
+      const result = await ingestGalleryImages('fig-9', [
+        { url: 'https://example.com/a.jpg' },
+        { url: 'https://example.com/b.jpg' }
+      ]);
+
+      expect(result).toEqual({ figureId: 'fig-9', imagesQueued: 2, duplicatesSkipped: 1 });
+    });
+
+    it('throws ImageManagerClientError with kind "timeout" when the request times out', async () => {
+      const timeoutError: any = new Error('timeout of 15000ms exceeded');
+      timeoutError.isAxiosError = true;
+      timeoutError.code = 'ECONNABORTED';
+      mockedAxios.post.mockRejectedValueOnce(timeoutError);
+      mockedAxios.isAxiosError.mockReturnValueOnce(true);
+
+      const promise = ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }]);
+      await expect(promise).rejects.toBeInstanceOf(ImageManagerClientError);
+      await expect(promise).rejects.toMatchObject({ kind: 'timeout' });
+    });
+
+    it('throws ImageManagerClientError with kind "http" and the response status on a non-2xx response', async () => {
+      const httpError: any = new Error('Request failed with status code 422');
+      httpError.isAxiosError = true;
+      httpError.response = { status: 422, data: { detail: 'validation error' } };
+      mockedAxios.post.mockRejectedValueOnce(httpError);
+      mockedAxios.isAxiosError.mockReturnValueOnce(true);
+
+      await expect(
+        ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }])
+      ).rejects.toMatchObject({
+        kind: 'http',
+        status: 422
+      });
+    });
+
+    it('throws ImageManagerClientError with kind "network" on connection refused', async () => {
+      const networkError: any = new Error('connect ECONNREFUSED 127.0.0.1:8000');
+      networkError.isAxiosError = true;
+      networkError.code = 'ECONNREFUSED';
+      networkError.request = {};
+      mockedAxios.post.mockRejectedValueOnce(networkError);
+      mockedAxios.isAxiosError.mockReturnValueOnce(true);
+
+      await expect(
+        ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }])
+      ).rejects.toMatchObject({
+        kind: 'network'
+      });
+    });
+
+    it('throws ImageManagerClientError with kind "unknown" on a non-axios error', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('something exploded'));
+      mockedAxios.isAxiosError.mockReturnValueOnce(false);
+
+      await expect(
+        ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }])
+      ).rejects.toMatchObject({
+        kind: 'unknown'
+      });
+    });
+
+    it('throws ImageManagerClientError with kind "unknown" on a malformed (schema-violating) response', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1' } // missing imagesQueued/duplicatesSkipped
+      });
+
+      await expect(
+        ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }])
+      ).rejects.toMatchObject({
+        kind: 'unknown'
+      });
+    });
+  });
+
+  describe('getGallery', () => {
+    it('GETs {IMAGE_MANAGER_URL}/galleries/{figureId}', async () => {
+      process.env.IMAGE_MANAGER_URL = 'http://image-manager:8000';
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', images: [], count: 0 }
+      });
+
+      await getGallery('fig-1');
+
+      const [url] = mockedAxios.get.mock.calls[0];
+      expect(url).toBe('http://image-manager:8000/galleries/fig-1');
+    });
+
+    it('sends a sane timeout and omits Authorization when no token configured', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', images: [], count: 0 }
+      });
+
+      await getGallery('fig-1');
+
+      const [, config] = mockedAxios.get.mock.calls[0];
+      expect(typeof config?.timeout).toBe('number');
+      expect(config?.timeout).toBeGreaterThan(0);
+      expect(config?.headers).not.toHaveProperty('Authorization');
+    });
+
+    it('sends an Authorization Bearer header when IMAGE_MANAGER_SERVICE_TOKEN is configured', async () => {
+      process.env.IMAGE_MANAGER_SERVICE_TOKEN = 'service-jwt-xyz';
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', images: [], count: 0 }
+      });
+
+      await getGallery('fig-1');
+
+      const [, config] = mockedAxios.get.mock.calls[0];
+      expect(config?.headers).toMatchObject({ Authorization: 'Bearer service-jwt-xyz' });
+    });
+
+    it('returns the parsed {figureId, images, count} response on success', async () => {
+      const images = [
+        { id: 1, url: '/serve/1', position: 0, caption: 'front' },
+        { id: 2, url: '/serve/2', position: 1 }
+      ];
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1', images, count: 2 }
+      });
+
+      const result = await getGallery('fig-1');
+
+      expect(result).toEqual({ figureId: 'fig-1', images, count: 2 });
+    });
+
+    it('throws ImageManagerClientError with kind "timeout" when the poll request times out', async () => {
+      const timeoutError: any = new Error('timeout of 5000ms exceeded');
+      timeoutError.isAxiosError = true;
+      timeoutError.code = 'ECONNABORTED';
+      mockedAxios.get.mockRejectedValueOnce(timeoutError);
+      mockedAxios.isAxiosError.mockReturnValueOnce(true);
+
+      await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'timeout' });
+    });
+
+    it('throws ImageManagerClientError with kind "http" and the response status on a non-2xx response', async () => {
+      const httpError: any = new Error('Request failed with status code 404');
+      httpError.isAxiosError = true;
+      httpError.response = { status: 404, data: { detail: 'not found' } };
+      mockedAxios.get.mockRejectedValueOnce(httpError);
+      mockedAxios.isAxiosError.mockReturnValueOnce(true);
+
+      await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'http', status: 404 });
+    });
+
+    it('throws ImageManagerClientError with kind "network" on connection refused', async () => {
+      const networkError: any = new Error('connect ECONNREFUSED 127.0.0.1:8000');
+      networkError.isAxiosError = true;
+      networkError.code = 'ECONNREFUSED';
+      networkError.request = {};
+      mockedAxios.get.mockRejectedValueOnce(networkError);
+      mockedAxios.isAxiosError.mockReturnValueOnce(true);
+
+      await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'network' });
+    });
+
+    it('throws ImageManagerClientError with kind "unknown" on a non-axios error', async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error('something exploded'));
+      mockedAxios.isAxiosError.mockReturnValueOnce(false);
+
+      await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'unknown' });
+    });
+
+    it('throws ImageManagerClientError with kind "unknown" on a malformed (schema-violating) response', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { figureId: 'fig-1' } // missing images/count
+      });
+
+      await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'unknown' });
+    });
+  });
+
+  describe('ImageManagerClientError', () => {
+    it('is an instance of Error with a message, kind, and optional status', () => {
+      const err = new ImageManagerClientError('boom', 'http', 500);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('boom');
+      expect(err.kind).toBe('http');
+      expect(err.status).toBe(500);
+    });
+
+    it('leaves status undefined for non-http kinds', () => {
+      const err = new ImageManagerClientError('boom', 'network');
+      expect(err.status).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
be-01: typed image-manager HTTP client (/galleries ingest + poll, typed errors, mTLS-ready seam, not wired). be-02: nested optional Figure.displayMeta matte/grounding contract per fc-shared; imageUrl preserved; MFCItem untouched. tsc clean, 45 new tests.