### PR TITLE
Rename image-manager client to media-manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,13 +31,13 @@ SCRAPER_SERVICE_URL=http://localhost:3080
 # SCRAPER_SERVICE_URL=http://scraper:3050
 # SCRAPER_SERVICE_URL=http://scraper-dev:3090
 
-# image-manager service (figure image matting + display metadata)
+# media-manager service (figure image matting + display metadata)
 # Local development
-IMAGE_MANAGER_URL=http://localhost:8000
+MEDIA_MANAGER_URL=http://localhost:8000
 # Docker/Coolify deployment (must match service/network name)
-# IMAGE_MANAGER_URL=http://image-manager:8000
+# MEDIA_MANAGER_URL=http://media-manager:8000
 # Optional service-to-service JWT sent as `Authorization: Bearer <token>`
-# IMAGE_MANAGER_SERVICE_TOKEN=your_service_token_here
+# MEDIA_MANAGER_SERVICE_TOKEN=your_service_token_here
 
 # Admin Bootstrap Token (optional)
 # Used for one-time admin privilege grant via POST /admin/bootstrap

--- a/src/models/Figure.ts
+++ b/src/models/Figure.ts
@@ -64,7 +64,7 @@ export interface IFigureContactBand {
 }
 
 /**
- * Display + grounding metadata that the image-manager service PRODUCES and
+ * Display + grounding metadata that the media-manager service PRODUCES and
  * fc-mobile CONSUMES. Frozen cross-service contract — mirrors fc-shared
  * FigureDisplayMeta exactly (nested object, all fields optional). Additive
  * only: imageUrl remains the untouched source-image fallback.
@@ -102,7 +102,7 @@ export interface IFigure extends Document {
   imageUrl?: string;
   imageUrls?: string[];
 
-  // Display + grounding metadata (image-manager -> fc-mobile contract)
+  // Display + grounding metadata (media-manager -> fc-mobile contract)
   displayMeta?: IFigureDisplayMeta;
 
   // Releases (supports multiple releases/rereleases)
@@ -252,8 +252,8 @@ const FigureSchema = new Schema<IFigure>(
     imageUrl: { type: String },
     imageUrls: { type: [String], default: [] },
 
-    // Display + grounding metadata (image-manager -> fc-mobile contract).
-    // No default: stays undefined until image-manager populates it.
+    // Display + grounding metadata (media-manager -> fc-mobile contract).
+    // No default: stays undefined until media-manager populates it.
     displayMeta: { type: DisplayMetaSchema },
 
     // Releases

--- a/src/services/mediaManagerClient.ts
+++ b/src/services/mediaManagerClient.ts
@@ -2,11 +2,11 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import * as https from 'https';
 
 /**
- * Typed HTTP client for the image-manager microservice.
+ * Typed HTTP client for the media-manager microservice.
  *
  * Scope note: this module is intentionally NOT wired into any route/controller
  * yet. It exists purely as the typed client + tests for a later phase that
- * will route figure images through image-manager for matting/derived metadata.
+ * will route figure images through media-manager for matting/derived metadata.
  */
 
 // ---------------------------------------------------------------------------
@@ -15,10 +15,10 @@ import * as https from 'https';
 
 // Read env vars at call time (not module load) so tests can set/change them,
 // mirroring the SCRAPER_SERVICE_URL pattern in figureController.ts.
-const getImageManagerUrl = (): string =>
-  process.env.IMAGE_MANAGER_URL || 'http://localhost:8000'; // NOSONAR - internal service URL from env
+const getMediaManagerUrl = (): string =>
+  process.env.MEDIA_MANAGER_URL || 'http://localhost:8000'; // NOSONAR - internal service URL from env
 
-const getServiceToken = (): string | undefined => process.env.IMAGE_MANAGER_SERVICE_TOKEN;
+const getServiceToken = (): string | undefined => process.env.MEDIA_MANAGER_SERVICE_TOKEN;
 
 // Ingest just enqueues a background job, so a generous timeout absorbs network
 // hiccups without much cost. The poll GET is expected to be called repeatedly
@@ -47,38 +47,38 @@ const buildHeaders = (): Record<string, string> => {
 // Errors
 // ---------------------------------------------------------------------------
 
-export type ImageManagerErrorKind = 'timeout' | 'network' | 'http' | 'unknown';
+export type MediaManagerErrorKind = 'timeout' | 'network' | 'http' | 'unknown';
 
-export class ImageManagerClientError extends Error {
-  readonly kind: ImageManagerErrorKind;
+export class MediaManagerClientError extends Error {
+  readonly kind: MediaManagerErrorKind;
   readonly status?: number;
 
-  constructor(message: string, kind: ImageManagerErrorKind, status?: number) {
+  constructor(message: string, kind: MediaManagerErrorKind, status?: number) {
     super(message);
-    this.name = 'ImageManagerClientError';
+    this.name = 'MediaManagerClientError';
     this.kind = kind;
     this.status = status;
   }
 }
 
-/** Classify any error thrown during a request and re-throw as ImageManagerClientError. Never lets a raw axios/network error escape. */
+/** Classify any error thrown during a request and re-throw as MediaManagerClientError. Never lets a raw axios/network error escape. */
 const handleRequestError = (error: unknown): never => {
   if (axios.isAxiosError(error)) {
     if (error.code === 'ECONNABORTED') {
-      throw new ImageManagerClientError(`image-manager request timed out: ${error.message}`, 'timeout');
+      throw new MediaManagerClientError(`media-manager request timed out: ${error.message}`, 'timeout');
     }
     if (error.response) {
-      throw new ImageManagerClientError(
-        `image-manager returned HTTP ${error.response.status}`,
+      throw new MediaManagerClientError(
+        `media-manager returned HTTP ${error.response.status}`,
         'http',
         error.response.status
       );
     }
-    throw new ImageManagerClientError(`image-manager network error: ${error.message}`, 'network');
+    throw new MediaManagerClientError(`media-manager network error: ${error.message}`, 'network');
   }
 
   const message = error instanceof Error ? error.message : String(error);
-  throw new ImageManagerClientError(`image-manager client error: ${message}`, 'unknown');
+  throw new MediaManagerClientError(`media-manager client error: ${message}`, 'unknown');
 };
 
 // ---------------------------------------------------------------------------
@@ -130,7 +130,7 @@ const isValidGetGalleryResponse = (data: any): data is GetGalleryResponse =>
 // ---------------------------------------------------------------------------
 
 /**
- * POST {IMAGE_MANAGER_URL}/galleries/ingest — queues the given images for
+ * POST {MEDIA_MANAGER_URL}/galleries/ingest — queues the given images for
  * matting/processing. The server's `position` field is required, so a caller
  * omitting `position` gets it defaulted to the image's array index here.
  */
@@ -161,7 +161,7 @@ export async function ingestGalleryImages(
   let response: AxiosResponse<IngestGalleryImagesResponse>;
   try {
     response = await axios.post<IngestGalleryImagesResponse>(
-      `${getImageManagerUrl()}/galleries/ingest`,
+      `${getMediaManagerUrl()}/galleries/ingest`,
       payload,
       config
     );
@@ -170,14 +170,14 @@ export async function ingestGalleryImages(
   }
 
   if (!isValidIngestResponse(response.data)) {
-    throw new ImageManagerClientError('image-manager returned a malformed ingest response', 'unknown');
+    throw new MediaManagerClientError('media-manager returned a malformed ingest response', 'unknown');
   }
 
   return response.data;
 }
 
 /**
- * GET {IMAGE_MANAGER_URL}/galleries/{figureId} — fetches matted gallery
+ * GET {MEDIA_MANAGER_URL}/galleries/{figureId} — fetches matted gallery
  * contents. Ingest is async, so a Phase-4 poller will call this repeatedly
  * until processing completes.
  */
@@ -190,13 +190,13 @@ export async function getGallery(figureId: string): Promise<GetGalleryResponse> 
 
   let response: AxiosResponse<GetGalleryResponse>;
   try {
-    response = await axios.get<GetGalleryResponse>(`${getImageManagerUrl()}/galleries/${figureId}`, config);
+    response = await axios.get<GetGalleryResponse>(`${getMediaManagerUrl()}/galleries/${figureId}`, config);
   } catch (error) {
     return handleRequestError(error);
   }
 
   if (!isValidGetGalleryResponse(response.data)) {
-    throw new ImageManagerClientError('image-manager returned a malformed gallery response', 'unknown');
+    throw new MediaManagerClientError('media-manager returned a malformed gallery response', 'unknown');
   }
 
   return response.data;

--- a/tests/models/Figure.test.ts
+++ b/tests/models/Figure.test.ts
@@ -356,7 +356,7 @@ describe('Figure Model', () => {
     });
   });
 
-  describe('displayMeta (image-manager -> fc-mobile contract)', () => {
+  describe('displayMeta (media-manager -> fc-mobile contract)', () => {
     // Mirrors fc-shared FigureDisplayMeta exactly: nested object, all fields
     // optional, contactBand a nested {centerXFrac, widthFrac}. Additive only —
     // imageUrl remains the untouched fallback.

--- a/tests/services/mediaManagerClient.test.ts
+++ b/tests/services/mediaManagerClient.test.ts
@@ -7,17 +7,17 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 import {
   ingestGalleryImages,
   getGallery,
-  ImageManagerClientError
-} from '../../src/services/imageManagerClient';
+  MediaManagerClientError
+} from '../../src/services/mediaManagerClient';
 
 const ORIGINAL_ENV = process.env;
 
-describe('imageManagerClient', () => {
+describe('mediaManagerClient', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     process.env = { ...ORIGINAL_ENV };
-    delete process.env.IMAGE_MANAGER_URL;
-    delete process.env.IMAGE_MANAGER_SERVICE_TOKEN;
+    delete process.env.MEDIA_MANAGER_URL;
+    delete process.env.MEDIA_MANAGER_SERVICE_TOKEN;
   });
 
   afterAll(() => {
@@ -25,7 +25,7 @@ describe('imageManagerClient', () => {
   });
 
   describe('ingestGalleryImages', () => {
-    it('POSTs to /galleries/ingest with the default URL when IMAGE_MANAGER_URL is unset', async () => {
+    it('POSTs to /galleries/ingest with the default URL when MEDIA_MANAGER_URL is unset', async () => {
       mockedAxios.post.mockResolvedValueOnce({
         status: 200,
         data: { figureId: 'fig-1', imagesQueued: 1, duplicatesSkipped: 0 }
@@ -38,8 +38,8 @@ describe('imageManagerClient', () => {
       expect(url).toMatch(/^http:\/\/localhost:\d+\/galleries\/ingest$/);
     });
 
-    it('POSTs to {IMAGE_MANAGER_URL}/galleries/ingest when the env var is set', async () => {
-      process.env.IMAGE_MANAGER_URL = 'http://image-manager:8000';
+    it('POSTs to {MEDIA_MANAGER_URL}/galleries/ingest when the env var is set', async () => {
+      process.env.MEDIA_MANAGER_URL = 'http://media-manager:8000';
       mockedAxios.post.mockResolvedValueOnce({
         status: 200,
         data: { figureId: 'fig-1', imagesQueued: 1, duplicatesSkipped: 0 }
@@ -48,7 +48,7 @@ describe('imageManagerClient', () => {
       await ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }]);
 
       const [url] = mockedAxios.post.mock.calls[0];
-      expect(url).toBe('http://image-manager:8000/galleries/ingest');
+      expect(url).toBe('http://media-manager:8000/galleries/ingest');
     });
 
     it('builds the wire payload with camelCase fields, defaulting missing position to array index', async () => {
@@ -89,8 +89,8 @@ describe('imageManagerClient', () => {
       expect(config?.timeout).toBeGreaterThan(0);
     });
 
-    it('sends an Authorization Bearer header when IMAGE_MANAGER_SERVICE_TOKEN is configured', async () => {
-      process.env.IMAGE_MANAGER_SERVICE_TOKEN = 'service-jwt-abc';
+    it('sends an Authorization Bearer header when MEDIA_MANAGER_SERVICE_TOKEN is configured', async () => {
+      process.env.MEDIA_MANAGER_SERVICE_TOKEN = 'service-jwt-abc';
       mockedAxios.post.mockResolvedValueOnce({
         status: 200,
         data: { figureId: 'fig-1', imagesQueued: 1, duplicatesSkipped: 0 }
@@ -116,7 +116,7 @@ describe('imageManagerClient', () => {
       expect(result).toEqual({ figureId: 'fig-9', imagesQueued: 2, duplicatesSkipped: 1 });
     });
 
-    it('throws ImageManagerClientError with kind "timeout" when the request times out', async () => {
+    it('throws MediaManagerClientError with kind "timeout" when the request times out', async () => {
       const timeoutError: any = new Error('timeout of 15000ms exceeded');
       timeoutError.isAxiosError = true;
       timeoutError.code = 'ECONNABORTED';
@@ -124,11 +124,11 @@ describe('imageManagerClient', () => {
       mockedAxios.isAxiosError.mockReturnValueOnce(true);
 
       const promise = ingestGalleryImages('fig-1', [{ url: 'https://example.com/a.jpg' }]);
-      await expect(promise).rejects.toBeInstanceOf(ImageManagerClientError);
+      await expect(promise).rejects.toBeInstanceOf(MediaManagerClientError);
       await expect(promise).rejects.toMatchObject({ kind: 'timeout' });
     });
 
-    it('throws ImageManagerClientError with kind "http" and the response status on a non-2xx response', async () => {
+    it('throws MediaManagerClientError with kind "http" and the response status on a non-2xx response', async () => {
       const httpError: any = new Error('Request failed with status code 422');
       httpError.isAxiosError = true;
       httpError.response = { status: 422, data: { detail: 'validation error' } };
@@ -143,7 +143,7 @@ describe('imageManagerClient', () => {
       });
     });
 
-    it('throws ImageManagerClientError with kind "network" on connection refused', async () => {
+    it('throws MediaManagerClientError with kind "network" on connection refused', async () => {
       const networkError: any = new Error('connect ECONNREFUSED 127.0.0.1:8000');
       networkError.isAxiosError = true;
       networkError.code = 'ECONNREFUSED';
@@ -158,7 +158,7 @@ describe('imageManagerClient', () => {
       });
     });
 
-    it('throws ImageManagerClientError with kind "unknown" on a non-axios error', async () => {
+    it('throws MediaManagerClientError with kind "unknown" on a non-axios error', async () => {
       mockedAxios.post.mockRejectedValueOnce(new Error('something exploded'));
       mockedAxios.isAxiosError.mockReturnValueOnce(false);
 
@@ -169,7 +169,7 @@ describe('imageManagerClient', () => {
       });
     });
 
-    it('throws ImageManagerClientError with kind "unknown" on a malformed (schema-violating) response', async () => {
+    it('throws MediaManagerClientError with kind "unknown" on a malformed (schema-violating) response', async () => {
       mockedAxios.post.mockResolvedValueOnce({
         status: 200,
         data: { figureId: 'fig-1' } // missing imagesQueued/duplicatesSkipped
@@ -184,8 +184,8 @@ describe('imageManagerClient', () => {
   });
 
   describe('getGallery', () => {
-    it('GETs {IMAGE_MANAGER_URL}/galleries/{figureId}', async () => {
-      process.env.IMAGE_MANAGER_URL = 'http://image-manager:8000';
+    it('GETs {MEDIA_MANAGER_URL}/galleries/{figureId}', async () => {
+      process.env.MEDIA_MANAGER_URL = 'http://media-manager:8000';
       mockedAxios.get.mockResolvedValueOnce({
         status: 200,
         data: { figureId: 'fig-1', images: [], count: 0 }
@@ -194,7 +194,7 @@ describe('imageManagerClient', () => {
       await getGallery('fig-1');
 
       const [url] = mockedAxios.get.mock.calls[0];
-      expect(url).toBe('http://image-manager:8000/galleries/fig-1');
+      expect(url).toBe('http://media-manager:8000/galleries/fig-1');
     });
 
     it('sends a sane timeout and omits Authorization when no token configured', async () => {
@@ -211,8 +211,8 @@ describe('imageManagerClient', () => {
       expect(config?.headers).not.toHaveProperty('Authorization');
     });
 
-    it('sends an Authorization Bearer header when IMAGE_MANAGER_SERVICE_TOKEN is configured', async () => {
-      process.env.IMAGE_MANAGER_SERVICE_TOKEN = 'service-jwt-xyz';
+    it('sends an Authorization Bearer header when MEDIA_MANAGER_SERVICE_TOKEN is configured', async () => {
+      process.env.MEDIA_MANAGER_SERVICE_TOKEN = 'service-jwt-xyz';
       mockedAxios.get.mockResolvedValueOnce({
         status: 200,
         data: { figureId: 'fig-1', images: [], count: 0 }
@@ -239,7 +239,7 @@ describe('imageManagerClient', () => {
       expect(result).toEqual({ figureId: 'fig-1', images, count: 2 });
     });
 
-    it('throws ImageManagerClientError with kind "timeout" when the poll request times out', async () => {
+    it('throws MediaManagerClientError with kind "timeout" when the poll request times out', async () => {
       const timeoutError: any = new Error('timeout of 5000ms exceeded');
       timeoutError.isAxiosError = true;
       timeoutError.code = 'ECONNABORTED';
@@ -249,7 +249,7 @@ describe('imageManagerClient', () => {
       await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'timeout' });
     });
 
-    it('throws ImageManagerClientError with kind "http" and the response status on a non-2xx response', async () => {
+    it('throws MediaManagerClientError with kind "http" and the response status on a non-2xx response', async () => {
       const httpError: any = new Error('Request failed with status code 404');
       httpError.isAxiosError = true;
       httpError.response = { status: 404, data: { detail: 'not found' } };
@@ -259,7 +259,7 @@ describe('imageManagerClient', () => {
       await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'http', status: 404 });
     });
 
-    it('throws ImageManagerClientError with kind "network" on connection refused', async () => {
+    it('throws MediaManagerClientError with kind "network" on connection refused', async () => {
       const networkError: any = new Error('connect ECONNREFUSED 127.0.0.1:8000');
       networkError.isAxiosError = true;
       networkError.code = 'ECONNREFUSED';
@@ -270,14 +270,14 @@ describe('imageManagerClient', () => {
       await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'network' });
     });
 
-    it('throws ImageManagerClientError with kind "unknown" on a non-axios error', async () => {
+    it('throws MediaManagerClientError with kind "unknown" on a non-axios error', async () => {
       mockedAxios.get.mockRejectedValueOnce(new Error('something exploded'));
       mockedAxios.isAxiosError.mockReturnValueOnce(false);
 
       await expect(getGallery('fig-1')).rejects.toMatchObject({ kind: 'unknown' });
     });
 
-    it('throws ImageManagerClientError with kind "unknown" on a malformed (schema-violating) response', async () => {
+    it('throws MediaManagerClientError with kind "unknown" on a malformed (schema-violating) response', async () => {
       mockedAxios.get.mockResolvedValueOnce({
         status: 200,
         data: { figureId: 'fig-1' } // missing images/count
@@ -287,9 +287,9 @@ describe('imageManagerClient', () => {
     });
   });
 
-  describe('ImageManagerClientError', () => {
+  describe('MediaManagerClientError', () => {
     it('is an instance of Error with a message, kind, and optional status', () => {
-      const err = new ImageManagerClientError('boom', 'http', 500);
+      const err = new MediaManagerClientError('boom', 'http', 500);
       expect(err).toBeInstanceOf(Error);
       expect(err.message).toBe('boom');
       expect(err.kind).toBe('http');
@@ -297,7 +297,7 @@ describe('imageManagerClient', () => {
     });
 
     it('leaves status undefined for non-http kinds', () => {
-      const err = new ImageManagerClientError('boom', 'network');
+      const err = new MediaManagerClientError('boom', 'network');
       expect(err.status).toBeUndefined();
     });
   });


### PR DESCRIPTION
A2a rename (mechanical: image-manager -> media-manager references; catalog->library docs where applicable). Grep-clean, scoped diff, tests green. Auto-created.